### PR TITLE
refactor: Extract duplicate resource query logic

### DIFF
--- a/src/azure_haymaker/orchestrator/cleanup.py
+++ b/src/azure_haymaker/orchestrator/cleanup.py
@@ -29,6 +29,74 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _query_azure_resources(
+    run_id: str,
+    subscription_ids: list[str] | None = None,
+    use_pagination: bool = False,
+) -> list[Resource]:
+    """Internal helper to query Azure Resource Graph for managed resources.
+
+    Consolidates the common query logic used by query_managed_resources
+    and verify_cleanup_complete.
+
+    Args:
+        run_id: Execution run ID to filter resources
+        subscription_ids: List of subscription IDs to query (empty list for all)
+        use_pagination: Whether to handle paginated results
+
+    Returns:
+        List of Resource objects matching the query
+    """
+    # Lazy import to avoid dependency requirement if module is only used with mocks
+    from azure.mgmt.resourcegraph import ResourceGraphClient
+    from azure.mgmt.resourcegraph.models import QueryRequest
+
+    credentials = DefaultAzureCredential()
+    resource_graph_client = ResourceGraphClient(credentials)
+
+    # Build KQL query for managed resources
+    query = (
+        f"Resources "
+        f"| where tags['AzureHayMaker-managed'] == 'true' "
+        f"| where tags['RunId'] == '{run_id}' "
+        f"| project id, type, name, tags"
+    )
+
+    resources: list[Resource] = []
+    skip_token = None
+
+    while True:
+        query_request = QueryRequest(
+            subscriptions=subscription_ids or [],
+            query=query,
+            skip_token=skip_token,
+        )
+        result = resource_graph_client.resources(query_request)
+
+        # Convert to Resource objects
+        if result.data and hasattr(result.data, "__iter__"):
+            for item in result.data:  # pyright: ignore[reportGeneralTypeIssues]
+                resource = Resource(
+                    resource_id=item.get("id"),
+                    resource_type=item.get("type"),
+                    resource_name=item.get("name"),
+                    scenario_name=item.get("tags", {}).get("Scenario", "unknown"),
+                    run_id=run_id,
+                    created_at=datetime.now(UTC),
+                    tags=item.get("tags", {}),
+                    status=ResourceStatus.EXISTS,
+                )
+                resources.append(resource)
+
+        # Check if there are more results (only when pagination is enabled)
+        if use_pagination and result.skip_token:
+            skip_token = result.skip_token
+        else:
+            break
+
+    return resources
+
+
 class CleanupStatus(str, Enum):
     """Status of cleanup operation."""
 
@@ -87,60 +155,17 @@ async def query_managed_resources(subscription_id: str, run_id: str) -> list[Res
     Raises:
         Exception: If Resource Graph API call fails
     """
-    # Lazy import to avoid dependency requirement if module is only used with mocks
-    from azure.mgmt.resourcegraph import ResourceGraphClient
-    from azure.mgmt.resourcegraph.models import QueryRequest
-
-    credentials = DefaultAzureCredential()
-    resource_graph_client = ResourceGraphClient(credentials)
-
-    resources = []
-    skip_token = None
-
-    # Build KQL query for managed resources
-    query = (
-        f"Resources "
-        f"| where tags['AzureHayMaker-managed'] == 'true' "
-        f"| where tags['RunId'] == '{run_id}' "
-        f"| project id, type, name, tags"
-    )
-
-    while True:
-        try:
-            query_request = QueryRequest(
-                subscriptions=[subscription_id],
-                query=query,
-                skip_token=skip_token,
-            )
-            result = resource_graph_client.resources(query_request)
-
-            # Convert to Resource objects
-            if result.data and hasattr(result.data, "__iter__"):
-                for item in result.data:  # pyright: ignore[reportGeneralTypeIssues]
-                    resource = Resource(
-                        resource_id=item.get("id"),
-                        resource_type=item.get("type"),
-                        resource_name=item.get("name"),
-                        scenario_name=item.get("tags", {}).get("Scenario", "unknown"),
-                        run_id=run_id,
-                        created_at=datetime.now(UTC),
-                        tags=item.get("tags", {}),
-                        status=ResourceStatus.EXISTS,
-                    )
-                    resources.append(resource)
-
-            # Check if there are more results
-            if result.skip_token:
-                skip_token = result.skip_token
-            else:
-                break
-
-        except Exception as e:
-            logger.error(f"Failed to query managed resources: {e}")
-            raise
-
-    logger.info(f"Found {len(resources)} managed resources for run {run_id}")
-    return resources
+    try:
+        resources = _query_azure_resources(
+            run_id=run_id,
+            subscription_ids=[subscription_id],
+            use_pagination=True,
+        )
+        logger.info(f"Found {len(resources)} managed resources for run {run_id}")
+        return resources
+    except Exception as e:
+        logger.error(f"Failed to query managed resources: {e}")
+        raise
 
 
 async def verify_cleanup_complete(run_id: str) -> CleanupReport:
@@ -160,43 +185,12 @@ async def verify_cleanup_complete(run_id: str) -> CleanupReport:
         Exception: If Resource Graph query fails
     """
     try:
-        # Lazy import to avoid dependency requirement if module is only used with mocks
-        from azure.mgmt.resourcegraph import ResourceGraphClient
-        from azure.mgmt.resourcegraph.models import QueryRequest
-
-        # Get subscription ID from environment or default
-        credentials = DefaultAzureCredential()
-        resource_graph_client = ResourceGraphClient(credentials)
-
-        # Query for remaining resources - use subscription wildcard
-        query = (
-            f"Resources "
-            f"| where tags['AzureHayMaker-managed'] == 'true' "
-            f"| where tags['RunId'] == '{run_id}' "
-            f"| project id, type, name, tags"
+        # Query for remaining resources across all subscriptions (empty list)
+        remaining_resources = _query_azure_resources(
+            run_id=run_id,
+            subscription_ids=[],  # Search all subscriptions
+            use_pagination=False,
         )
-
-        query_request = QueryRequest(
-            subscriptions=[],  # Will search all subscriptions
-            query=query,
-        )
-
-        result = resource_graph_client.resources(query_request)
-
-        remaining_resources = []
-        if result.data and hasattr(result.data, "__iter__"):
-            for item in result.data:  # pyright: ignore[reportGeneralTypeIssues]
-                resource = Resource(
-                    resource_id=item.get("id"),
-                    resource_type=item.get("type"),
-                    resource_name=item.get("name"),
-                    scenario_name=item.get("tags", {}).get("Scenario", "unknown"),
-                    run_id=run_id,
-                    created_at=datetime.now(UTC),
-                    tags=item.get("tags", {}),
-                    status=ResourceStatus.EXISTS,
-                )
-                remaining_resources.append(resource)
 
         if not remaining_resources:
             status = CleanupStatus.VERIFIED


### PR DESCRIPTION
## Summary

- Extract common Azure Resource Graph query logic into `_query_azure_resources()` internal helper function
- Refactor `query_managed_resources()` to use the shared helper with pagination enabled
- Refactor `verify_cleanup_complete()` to use the shared helper without pagination (searches all subscriptions)

This eliminates ~60 lines of duplicate code while maintaining the same behavior and full test coverage.

Fixes #77

## Test plan

- [x] All 21 existing unit tests pass
- [x] Python syntax validation passes
- [x] `query_managed_resources` uses helper with pagination enabled
- [x] `verify_cleanup_complete` uses helper with pagination disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)