### PR TITLE
fix: Critical bugs in AI email generation and Graph API integration

### DIFF
--- a/src/azure_haymaker/knowledge_worker/content/email_generator.py
+++ b/src/azure_haymaker/knowledge_worker/content/email_generator.py
@@ -215,8 +215,11 @@ class EmailContentGenerator:
                 f"(activity #{activity_count})"
             )
 
+            # Use specified model or default to claude-3-5-sonnet-latest
+            model = self.config.model if self.config.model else "claude-3-5-sonnet-latest"
+
             response = self.client.messages.create(
-                model=self.config.model,
+                model=model,
                 max_tokens=self.config.max_tokens,
                 temperature=self.config.temperature,
                 system=system_prompt,

--- a/src/azure_haymaker/knowledge_worker/operations/email.py
+++ b/src/azure_haymaker/knowledge_worker/operations/email.py
@@ -151,14 +151,51 @@ class EmailOperations(M365OperationBase):
 
         try:
             # Send via Graph API
+            from msgraph.generated.users.item.send_mail.send_mail_post_request_body import SendMailPostRequestBody
+            from msgraph.generated.models.message import Message
+            from msgraph.generated.models.recipient import Recipient
+            from msgraph.generated.models.email_address import EmailAddress
+            from msgraph.generated.models.item_body import ItemBody
+
+            # Create proper Message object with proper nested objects
+            message = Message()
+            message.subject = message_data["subject"]
+
+            # Create ItemBody object (not dict)
+            body_obj = ItemBody()
+            body_obj.content_type = message_data["body"]["contentType"]
+            body_obj.content = message_data["body"]["content"]
+            message.body = body_obj
+
+            # Create Recipient objects (not dicts)
+            message.to_recipients = [
+                Recipient(email_address=EmailAddress(address=addr["emailAddress"]["address"]))
+                for addr in message_data["toRecipients"]
+            ]
+
+            if "ccRecipients" in message_data:
+                message.cc_recipients = [
+                    Recipient(email_address=EmailAddress(address=addr["emailAddress"]["address"]))
+                    for addr in message_data["ccRecipients"]
+                ]
+
+            if "bccRecipients" in message_data:
+                message.bcc_recipients = [
+                    Recipient(email_address=EmailAddress(address=addr["emailAddress"]["address"]))
+                    for addr in message_data["bccRecipients"]
+                ]
+
+            message.importance = message_data.get("importance", "normal")
+
+            # Create request body
+            request_body = SendMailPostRequestBody(
+                message=message,
+                save_to_sent_items=save_to_sent
+            )
+
             result = await self.client.graph.users.by_user_id(
                 self.worker.entra_object_id
-            ).send_mail.post(
-                body={
-                    "message": message_data,
-                    "saveToSentItems": save_to_sent,
-                }
-            )
+            ).send_mail.post(request_body)
 
             self._log_operation(
                 "email_send",


### PR DESCRIPTION
## Summary

Fixes two critical bugs preventing emails from being sent in KW deployments.

## Bug 1: Anthropic API Model Parameter
- **Error**: 'model: Input should be a valid string'
- **Cause**: Passing model=None to Anthropic API
- **Fix**: Use 'claude-3-5-sonnet-latest' when model is None
- **File**: email_generator.py line 219

## Bug 2: Graph API Serialization
- **Error**: 'dict' object has no attribute 'serialize'
- **Cause**: Graph API send_mail expects proper objects, not dicts
- **Fix**: Create Message, Recipient, EmailAddress, ItemBody objects
- **File**: email.py lines 154-198

## Impact

HIGH - These bugs blocked all email sending in Knowledge Worker deployments

## Testing

Deployed 5 workers twice - errors occurred in both deployments before fix.

## Files Modified

- src/azure_haymaker/knowledge_worker/content/email_generator.py
- src/azure_haymaker/knowledge_worker/operations/email.py

Closes #159