### PR TITLE
fix(security): Remove hardcoded credentials from infrastructure templates

### DIFF
--- a/.claude/context/DISCOVERIES.md
+++ b/.claude/context/DISCOVERIES.md
@@ -8,6 +8,7 @@ This file documents non-obvious problems, solutions, and patterns discovered dur
 
 ### Recent (January 2026)
 
+- [PM Analysis: Security Issues Block Production Deployment](#pm-analysis-security-issues-block-production-2026-01-15)
 - [Integration Tests Hang 77+ Minutes - Cumulative Timeout Problem](#integration-tests-hang-77-minutes-2026-01-12)
 
 ### December 2025
@@ -34,6 +35,59 @@ This file documents non-obvious problems, solutions, and patterns discovered dur
 - [Pattern Applicability Framework](#pattern-applicability-analysis-framework-2025-10-20)
 - [Socratic Questioning Pattern](#socratic-questioning-pattern-2025-10-18)
 - [Expert Agent Creation Pattern](#expert-agent-creation-pattern-2025-10-18)
+
+---
+
+## PM Analysis: Security Issues Block Production Deployment (2026-01-15)
+
+### Context
+
+PM skills analysis (backlog-curator, roadmap-strategist patterns) applied to 30 open GitHub issues to identify optimal work priorities for AzureHayMaker.
+
+### Key Finding
+
+**Two CRITICAL security issues are blocking production deployment regardless of feature completeness:**
+
+| Issue | Title | Risk |
+|-------|-------|------|
+| #49 | Remove hardcoded SSH key from vm-dev.bicepparam | Security exposure |
+| #51 | Disable ACR admin user and credential outputs | Security exposure |
+
+### Multi-Criteria Scoring Results
+
+Applied backlog-curator scoring (Priority 40%, Blocking 30%, Ease 20%, Goals 10%):
+
+| Tier | Issues | Score | Rationale |
+|------|--------|-------|-----------|
+| **1: Security** | #49, #51 | 100/100 | Blocks production, simple fixes |
+| **2: P0 Feature** | #145 | 92/100 | Core feature, P0-critical label |
+| **3: P1 Foundation** | #147, #127, #128, #129, #126 | 85/100 | Infrastructure, Phase 1 momentum |
+| **4: Code Quality** | #52, #48, #50 | 78/100 | Philosophy violations (2752/1065 lines) |
+| **5: Bugs** | #165, #164, #30 | 65/100 | Dev workflow friction |
+
+### Strategic Insights
+
+1. **Cross-tenant momentum**: PR #197 (Phase 1) just merged - continue to Phase 2 while context is fresh
+2. **Code quality debt**: power_steering_checker.py (2752 lines) and orchestrator.py (1065 lines) violate 50-line philosophy limit by 55x and 21x respectively
+3. **Test infrastructure fixed**: PR #194 resolved 77+ min integration test hangs
+
+### Recommended Work Order
+
+1. **Immediate**: #49 + #51 (Security) - 2-4 hours
+2. **Then**: #165 + #164 (Pre-commit alignment) - 1-2 hours
+3. **Next Sprint**: #147 Phase 2 (Cross-tenant), #127 (Tracing)
+4. **Then**: #145 (P0 Dynamic Scenario Modeling)
+5. **Tech Debt**: #52, #48, #50 (Refactoring)
+
+### Why Security First
+
+Hardcoded credentials and admin users are deployment blockers. No amount of feature work matters if security prevents production release.
+
+### Related
+
+- Session log: `.claude/runtime/logs/investigation_pm_analysis_20260115_190419/`
+- Skills used: backlog-curator, roadmap-strategist
+- Data sources: GitHub Issues (30), PRs (10 recent), DISCOVERIES.md
 
 ---
 

--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -145,6 +145,7 @@ module containerAppsEnv 'modules/container-apps-env.bicep' = {
 }
 
 // Container Registry (Optional for dev - SKU limitations in some subscriptions)
+// SECURITY: Admin user disabled - use managed identities for authentication
 module containerRegistry 'modules/container-registry.bicep' = if (environment != 'dev') {
   name: 'containerRegistry-${uniqueSuffix}'
   params: {
@@ -152,7 +153,7 @@ module containerRegistry 'modules/container-registry.bicep' = if (environment !=
     location: location
     tags: commonTags
     sku: 'Premium'
-    adminUserEnabled: true
+    adminUserEnabled: false
   }
 }
 

--- a/infra/bicep/modules/container-registry.bicep
+++ b/infra/bicep/modules/container-registry.bicep
@@ -20,8 +20,8 @@ param tags object = {}
 ])
 param sku string = 'Premium'
 
-@description('Enable admin user')
-param adminUserEnabled bool = true
+@description('Enable admin user (disabled by default for security - use managed identities instead)')
+param adminUserEnabled bool = false
 
 // Container Registry
 resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
@@ -55,8 +55,7 @@ resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-07-01' =
 }
 
 // Outputs
+// SECURITY: Do NOT output credentials - use managed identities for authentication
 output registryId string = containerRegistry.id
 output registryName string = containerRegistry.name
 output loginServer string = containerRegistry.properties.loginServer
-output adminUsername string = containerRegistry.listCredentials().username
-output adminPassword string = containerRegistry.listCredentials().passwords[0].value

--- a/infra/bicep/modules/servicebus.bicep
+++ b/infra/bicep/modules/servicebus.bicep
@@ -91,4 +91,5 @@ output namespaceName string = serviceBusNamespace.name
 output topicName string = agentLogsTopic.name
 output queueName string = executionRequestsQueue.name
 output endpoint string = serviceBusNamespace.properties.serviceBusEndpoint
+// NOTE: Connection string is passed securely to function app - consider migrating to managed identity
 output connectionString string = listKeys('${serviceBusNamespace.id}/AuthorizationRules/RootManageSharedAccessKey', serviceBusNamespace.apiVersion).primaryConnectionString

--- a/infra/bicep/modules/storage.bicep
+++ b/infra/bicep/modules/storage.bicep
@@ -121,4 +121,5 @@ resource rateLimitsTable 'Microsoft.Storage/storageAccounts/tableServices/tables
 output storageAccountId string = storageAccount.id
 output storageAccountName string = storageAccount.name
 output primaryEndpoints object = storageAccount.properties.primaryEndpoints
+// NOTE: Connection string is passed securely to function app - consider migrating to managed identity
 output connectionString string = 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};AccountKey=${storageAccount.listKeys().keys[0].value};EndpointSuffix=${environment().suffixes.storage}'

--- a/infra/bicep/parameters/vm-dev.bicepparam
+++ b/infra/bicep/parameters/vm-dev.bicepparam
@@ -3,4 +3,7 @@ using '../main-vm.bicep'
 param environment = 'dev'
 param adminObjectIds = ['42d7dce2-072a-4ff4-9c3c-11474f4fc7df']
 param githubOidcClientId = '7fc87f52-c911-49ce-b64f-e4f22fa7c8b0'
-param sshPublicKey = 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXL/CnsziUa6Rn/xoFq+HiyLx++q29ersziJIQ/Yz4LRSoscF6cw/tYkf7rORv0LYD6jf9AcOSi62eJnB6hZr353WcPssM3xmPc/PjLMV1lZGe6Y50tZBj9HXObE/+ox+Djtvnb1LiHZYiYHDMKZXe5F3WZb2PxTvQUuHftjhgW57Aekedxz2Vrguo2k0fAjKjXL9Vr6YciY3Ppy4vC15yR9TR/bvKj188vR2JXgjfRfX//KuFjS4dbhz0XIhT1D8TPgEq5ES3PHvBalknGqwFDZZ2pBYn9tDc1ZjzPEJer8Q80qOOVYnA4wywx6mA9HBfa/48qpMGG1ulr5JPKoE2iGyYWSnk/+UODgLgqKkC4M2PyHZZ+EJ9PNGxpHyMT8NuEm3kxAbFsHLEhQYofALGjA46Me/BEoP5+jvoeX8onZfTosYGUgImcAAKQahpNCUFrxE30QhIi/YAA6SzywKKeEmuBxdhPeE+hWGGKzU9Fna26gSA63sWqlx52JjRfSovdmA2HX22Z0AipRBFYpLnaFRAaWPNQhkGO8OaEkpXCjbKQYzc5oc0HYPvS4zSXOaewITLuhzVxs/XtrZnbjyr5DmrrN11jqD89OylDFPFSLUXAbVQ13ZXnPmao+qfeQQy2dof3P/2XzyjCWHelPO3KuEsZ5hv2RsAvc3w3l+P+Q== haymaker-orchestrator'
+// SSH key must be provided via environment variable SSH_PUBLIC_KEY at deployment time
+// Do NOT hardcode SSH keys in version control
+// Example: az deployment group create ... --parameters sshPublicKey="$SSH_PUBLIC_KEY"
+param sshPublicKey = ''


### PR DESCRIPTION
## Summary

Fixes #49, #51

This PR addresses two CRITICAL security issues identified in the infrastructure templates:

### Issue #49: Hardcoded SSH Key
- **Before**: SSH public key was hardcoded in `vm-dev.bicepparam` (line 6)
- **After**: SSH key parameter is empty with comments explaining secure deployment
- **Impact**: Prevents credential exposure in version control

### Issue #51: ACR Admin User and Credentials
- **Before**: ACR admin user enabled by default, credentials output in deployment
- **After**: ACR admin user disabled by default, credential outputs removed
- **Impact**: Forces use of managed identities for ACR authentication

## Changes

| File | Change |
|------|--------|
| `vm-dev.bicepparam` | Removed hardcoded SSH key |
| `container-registry.bicep` | Default `adminUserEnabled` to `false`, removed credential outputs |
| `main.bicep` | Updated to pass `adminUserEnabled: false` for ACR |
| `storage.bicep` | Added note about managed identity migration |
| `servicebus.bicep` | Added note about managed identity migration |
| `DISCOVERIES.md` | Documented PM priority analysis findings |

## Deployment Changes

After this change, deployers must provide the SSH public key at deployment time:

```bash
az deployment group create ... --parameters sshPublicKey="$SSH_PUBLIC_KEY"
```

## Test Plan

- [x] Validated all bicep files compile successfully (`az bicep build`)
- [ ] CI checks pass
- [ ] Manual deployment test (optional - infrastructure change)

## Security Checklist

- [x] No credentials in version control
- [x] ACR admin user disabled
- [x] ACR credential outputs removed
- [x] Clear instructions for secure deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)