### PR TITLE
fix: Align pre-commit hooks with CI validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,9 +12,8 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.8.5
     hooks:
-      # Run the linter
+      # Run the linter (no --fix to match CI behavior - errors must be fixed manually)
       - id: ruff
-        args: [--fix]
       # Run the formatter
       - id: ruff-format
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ See the [Knowledge Worker Framework documentation](docs/knowledge-worker-framewo
 
 ```bash
 uv sync --all-extras
+pre-commit install  # Install git hooks for code quality
 ```
 
 ### 2. Configure Environment
@@ -374,14 +375,17 @@ curl https://haymaker-fastapi-app.azurewebsites.net/api/metrics | jq
 ## Development
 
 ```bash
+# First-time setup: Install pre-commit hooks
+pre-commit install
+
 # Run tests
 pytest
 
 # Linting and type checking
-ruff check .
+ruff check src/
 pyright
 
-# Pre-commit hooks
+# Pre-commit hooks (run manually on all files)
 pre-commit run --all-files
 ```
 


### PR DESCRIPTION
## Summary

Fixes #164, #165

This PR aligns the pre-commit hook configuration with CI validation to ensure developers catch linting errors locally before pushing.

## Problem

1. **#164**: Pre-commit used `ruff --fix` which auto-fixed errors silently, while CI used `ruff check` which reported them. Result: errors passed pre-commit but failed CI.

2. **#165**: `pre-commit install` was never documented, so hooks weren't actually running for most developers.

## Solution

| Before | After |
|--------|-------|
| `ruff --fix` (auto-fix) | `ruff` (report only) |
| No install docs | `pre-commit install` in Quick Start |
| `ruff check .` | `ruff check src/` (match CI scope) |

## Changes

- `.pre-commit-config.yaml`: Remove `--fix` from ruff hook
- `README.md`: Add `pre-commit install` to Quick Start and Development sections

## Test Plan

- [x] Pre-commit config syntax valid
- [ ] CI passes
- [ ] Manually verify pre-commit reports errors (doesn't auto-fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)