### PR TITLE
fix(zero-bs): Remove unused IMAGE_SIGNATURE_REGISTRY constant

### DIFF
--- a/src/azure_haymaker/orchestrator/image_verifier.py
+++ b/src/azure_haymaker/orchestrator/image_verifier.py
@@ -17,14 +17,6 @@ class ImageSigningError(Exception):
     pass
 
 
-# Container image signature verification configuration
-# Maps container image names to their expected SHA256 digests (signed)
-IMAGE_SIGNATURE_REGISTRY = {
-    # Format: "registry/image:tag": "sha256:digest"
-    # These must be pre-populated with verified image digests from your container registry
-}
-
-
 class ImageVerifier:
     """Validates container image signatures and registry policies.
 


### PR DESCRIPTION
## Summary
- Remove dead code: `IMAGE_SIGNATURE_REGISTRY` constant was declared but never used
- The constant was documented as "must be pre-populated" but never referenced by `verify_signature` method
- Following Zero-BS philosophy: no dead code

## Investigation Notes
The original issue #17 listed three violations:
1. **TODO in agents_api.py:287** - Already fixed (no longer exists)
2. **placeholder log storage** - Already fixed (properly implemented with Cosmos DB)
3. **empty IMAGE_SIGNATURE_REGISTRY** - Fixed in this PR (removed dead code)

## Test plan
- [x] All 34 container manager tests pass
- [x] Image signature verification continues to work (tests cover all verification paths)
- [x] No code references the removed constant

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)