### PR TITLE
fix: Standardize skill filenames and add missing frontmatter

### DIFF
--- a/.claude/skills/azure-devops-cli/SKILL.md
+++ b/.claude/skills/azure-devops-cli/SKILL.md
@@ -1,37 +1,31 @@
-# Azure DevOps CLI Skill
-
 ---
-
 name: azure-devops-cli
-description: Expert guidance for Azure DevOps CLI (az devops) - automation, pipelines, repos, boards, and artifacts management. Use when working with Azure DevOps, managing pipelines, creating work items, or when user mentions ADO, builds, releases, or Azure repos.
-keywords:
-
-- azure devops
-- az devops
-- ado cli
-- pipelines
-- azure pipelines
-- boards
-- azure boards
-- repos
-- azure repos
-- artifacts
-- azure artifacts
-- yaml pipeline
-- build pipeline
-- release pipeline
-- work items
-- pull requests
-- git repos
-- artifacts feed
-
-<!-- prettier-ignore-start -->
-auto_activate: true
 version: 1.0.0
+description: Expert guidance for Azure DevOps CLI (az devops) - automation, pipelines, repos, boards, and artifacts management. Use when working with Azure DevOps, managing pipelines, creating work items, or when user mentions ADO, builds, releases, or Azure repos.
+auto_activate: true
 token_budget: 1800
-<!-- prettier-ignore-end -->
-
+keywords:
+  - azure devops
+  - az devops
+  - ado cli
+  - pipelines
+  - azure pipelines
+  - boards
+  - azure boards
+  - repos
+  - azure repos
+  - artifacts
+  - azure artifacts
+  - yaml pipeline
+  - build pipeline
+  - release pipeline
+  - work items
+  - pull requests
+  - git repos
+  - artifacts feed
 ---
+
+# Azure DevOps CLI Skill
 
 ## Quick Start
 

--- a/.claude/skills/backlog-curator/SKILL.md
+++ b/.claude/skills/backlog-curator/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: backlog-curator
+version: 1.0.0
 description: Expert backlog manager that prioritizes work using multi-criteria scoring, analyzes dependencies, and recommends optimal next tasks. Activates when managing backlogs, prioritizing work, adding items, or analyzing what to work on next.
 ---
 

--- a/.claude/skills/eval-recipes-runner/SKILL.md
+++ b/.claude/skills/eval-recipes-runner/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: eval-recipes-runner
+version: 1.0.0
+description: Run Microsoft's eval-recipes benchmarks to validate amplihack improvements against baseline agents. Activates when testing with eval-recipes, running evals, or benchmarking changes.
+---
+
 # eval-recipes Runner Skill
 
 ## Purpose

--- a/.claude/skills/microsoft-agent-framework/SKILL.md
+++ b/.claude/skills/microsoft-agent-framework/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: microsoft-agent-framework
+version: 0.1.0-preview
+description: Expert knowledge of Microsoft Agent Framework for building production AI agents and workflows. Use when building agents with Microsoft's framework, multi-agent orchestration, or tool integration.
+---
+
 # Microsoft Agent Framework Skill
 
 **Version**: 0.1.0-preview | **Last Updated**: 2025-11-15 | **Framework Version**: 0.1.0-preview

--- a/.claude/skills/pm-architect/SKILL.md
+++ b/.claude/skills/pm-architect/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: pm-architect
+version: 1.0.0
 description: Expert project manager orchestrating backlog-curator, work-delegator, workstream-coordinator, and roadmap-strategist sub-skills. Coordinates complex software projects through delegation and strategic oversight. Activates when managing projects, coordinating work, or tracking overall progress.
 ---
 

--- a/.claude/skills/roadmap-strategist/SKILL.md
+++ b/.claude/skills/roadmap-strategist/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: roadmap-strategist
+version: 1.0.0
 description: Expert strategist managing project roadmaps, goals, milestones, and strategic direction. Tracks goal progress, ensures alignment, and provides strategic recommendations. Activates when planning roadmaps, setting goals, tracking milestones, or discussing strategic direction.
 ---
 

--- a/.claude/skills/work-delegator/SKILL.md
+++ b/.claude/skills/work-delegator/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: work-delegator
+version: 1.0.0
 description: Expert delegation specialist that creates comprehensive context packages for coding agents, analyzes requirements, identifies relevant files, and generates clear instructions. Activates when delegating work, assigning tasks, creating delegation packages, or preparing agent instructions.
 ---
 

--- a/.claude/skills/workstream-coordinator/SKILL.md
+++ b/.claude/skills/workstream-coordinator/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: workstream-coordinator
+version: 1.0.0
 description: Expert workstream coordinator managing multiple concurrent tasks, tracking progress, detecting conflicts and stalls, analyzing dependencies, and ensuring smooth parallel execution. Activates when coordinating workstreams, tracking progress, checking status, or managing concurrent work.
 ---
 


### PR DESCRIPTION
## Summary
- Rename 8 skill files from `skill.md` to `SKILL.md` for consistency
- Fix malformed frontmatter in `azure-devops-cli/SKILL.md`
- Add missing YAML frontmatter to `eval-recipes-runner/SKILL.md`
- Add missing YAML frontmatter to `microsoft-agent-framework/SKILL.md`
- Add missing `version` field to 6 skills

## Files Changed
All 8 skills listed in issue #57:
- azure-devops-cli
- backlog-curator
- eval-recipes-runner
- microsoft-agent-framework
- pm-architect
- roadmap-strategist
- work-delegator
- workstream-coordinator

## Acceptance Criteria
- [x] All skills use SKILL.md (not skill.md)
- [x] All skills have YAML frontmatter with `---` delimiters
- [x] All skills have version field

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)