### PR TITLE
feat: Add Phase 2 multi-tenant configuration support (#147)

### DIFF
--- a/docs/guides/CROSS_TENANT_SETUP.md
+++ b/docs/guides/CROSS_TENANT_SETUP.md
@@ -2,11 +2,21 @@
 
 ## Overview
 
-Enable Azure HayMaker to deploy scenarios from an orchestrator tenant (Tenant A) to a different target tenant (Tenant B).
+Enable Azure HayMaker to deploy scenarios from an orchestrator tenant (Tenant A) to different target tenants (Tenant B, C, D...).
 
-**Use Case**: Run orchestrator in "infrastructure tenant", deploy resources to "customer tenant".
+**Use Case**: Run orchestrator in "infrastructure tenant", deploy resources to "customer tenants".
+
+## Phase Support
+
+| Phase | Feature | Status |
+|-------|---------|--------|
+| Phase 1 MVP | Single target tenant with explicit credentials | Supported |
+| Phase 2 | Multi-tenant registry with Key Vault storage | Supported |
+| Phase 3+ | Fan-out, CLI management, auto-discovery | Planned |
 
 **Phase 1 MVP Scope**: Deploy one scenario to a single different Azure tenant using explicit cross-tenant credentials, with tenant-aware logging and storage partitioning.
+
+**Phase 2 Scope**: Configure multiple tenants in a registry (stored in Key Vault), with thread-safe credential caching and programmatic tenant selection.
 
 ## Prerequisites
 
@@ -97,6 +107,189 @@ az ad sp create-for-rbac \
 ```
 
 **Critical**: Target tenant SP needs **Application.ReadWrite.All** to create ephemeral service principals for scenarios.
+
+## Phase 2: Multi-Tenant Registry Configuration
+
+Phase 2 adds support for managing multiple tenants through a registry stored in Key Vault.
+
+### Key Vault Secret Structure
+
+Store tenant configurations as JSON in Key Vault following this naming convention:
+
+```
+tenant-{prefix}-config  -> JSON configuration
+tenant-{prefix}-secret  -> SP client secret (plain text)
+```
+
+#### Config Secret Format (JSON)
+
+```bash
+# Create tenant config secret
+az keyvault secret set \
+  --vault-name <orchestrator-key-vault> \
+  --name "tenant-customerA-config" \
+  --value '{
+    "tenant_id": "12345678-1234-1234-1234-123456789abc",
+    "subscription_id": "87654321-4321-4321-4321-cba987654321",
+    "sp_client_id": "abcdef12-3456-7890-abcd-ef1234567890",
+    "display_name": "Customer A",
+    "enabled": true,
+    "resource_group": "rg-customerA-haymaker"
+  }'
+
+# Create corresponding secret
+az keyvault secret set \
+  --vault-name <orchestrator-key-vault> \
+  --name "tenant-customerA-secret" \
+  --value "<sp-client-secret>"
+```
+
+#### Configuration Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| tenant_id | Yes | Azure AD tenant ID |
+| subscription_id | Yes | Target subscription for deployments |
+| sp_client_id | Yes | Service principal client ID |
+| display_name | No | Human-readable name for logging |
+| enabled | No | Whether tenant is active (default: true) |
+| resource_group | No | Default resource group for deployments |
+
+### Loading Multi-Tenant Configuration
+
+#### Automatic Loading
+
+Use `load_config_with_tenants()` to automatically discover and load tenant configs from Key Vault:
+
+```python
+from azure_haymaker.orchestrator.config import load_config_with_tenants
+
+# Load all tenants
+config = await load_config_with_tenants()
+print(f"Loaded {len(config.tenants)} tenants")
+
+# Load with prefix filter (e.g., only production tenants)
+config = await load_config_with_tenants(tenant_prefix_filter="prod")
+
+# Skip Key Vault loading (fall back to Phase 1 behavior)
+config = await load_config_with_tenants(load_tenants_from_keyvault=False)
+```
+
+#### Manual Loading
+
+For more control, load tenants manually:
+
+```python
+from azure.keyvault.secrets import SecretClient
+from azure.identity import DefaultAzureCredential
+from azure_haymaker.orchestrator.config import load_tenant_configs_from_keyvault
+
+credential = DefaultAzureCredential()
+kv_client = SecretClient(vault_url="https://my-vault.vault.azure.net", credential=credential)
+
+tenants = load_tenant_configs_from_keyvault(kv_client)
+for tenant_id, config in tenants.items():
+    print(f"Tenant: {config.display}")
+```
+
+### Using Multi-Tenant Credentials
+
+#### Get Credential for Specific Tenant
+
+```python
+from azure_haymaker.utils.credentials import get_tenant_credential
+
+# Phase 2: Get credential for specific tenant from registry
+credential = get_tenant_credential(config, tenant_id="12345678-...")
+
+# Falls back to Phase 1 behavior if tenant not in registry
+```
+
+#### Direct Factory Access
+
+```python
+from azure_haymaker.utils.credentials import MultiTenantCredentialFactory
+
+# Get cached credential for tenant
+tenant_config = config.get_tenant_config("12345678-...")
+credential = MultiTenantCredentialFactory.get_credential_for_tenant(tenant_config)
+
+# Clear cache for specific tenant
+MultiTenantCredentialFactory.clear_cache("12345678-...")
+
+# Clear all cached credentials
+MultiTenantCredentialFactory.clear_cache()
+```
+
+### Listing and Managing Tenants
+
+```python
+# List all enabled tenants
+for tenant in config.list_tenants():
+    print(f"Tenant: {tenant.display}")
+
+# List all tenants including disabled
+for tenant in config.list_tenants(include_disabled=True):
+    print(f"Tenant: {tenant.display}")
+
+# Get specific tenant config
+tenant = config.get_tenant_config("12345678-...")
+if tenant:
+    print(f"Found: {tenant.display}")
+
+# Check if registry has any tenants
+if config.has_multi_tenant_registry:
+    print(f"Multi-tenant mode with {len(config.tenants)} tenant(s)")
+```
+
+### Adding New Tenants
+
+To add a new tenant to the registry:
+
+1. Create the service principal in the target tenant (same as Phase 1)
+2. Add config and secret to Key Vault:
+
+```bash
+# Add config
+az keyvault secret set \
+  --vault-name <orchestrator-key-vault> \
+  --name "tenant-newcustomer-config" \
+  --value '{
+    "tenant_id": "<new-tenant-id>",
+    "subscription_id": "<new-subscription-id>",
+    "sp_client_id": "<new-sp-client-id>",
+    "display_name": "New Customer",
+    "enabled": true
+  }'
+
+# Add secret
+az keyvault secret set \
+  --vault-name <orchestrator-key-vault> \
+  --name "tenant-newcustomer-secret" \
+  --value "<new-sp-secret>"
+```
+
+3. Restart orchestrator or reload configuration to pick up new tenant.
+
+### Disabling Tenants
+
+To temporarily disable a tenant without removing it:
+
+```bash
+# Update config with enabled=false
+az keyvault secret set \
+  --vault-name <orchestrator-key-vault> \
+  --name "tenant-customerA-config" \
+  --value '{
+    "tenant_id": "...",
+    "subscription_id": "...",
+    "sp_client_id": "...",
+    "display_name": "Customer A",
+    "enabled": false
+  }'
+```
+
+Disabled tenants are not returned by `get_tenant_config()` or `list_tenants()` (unless `include_disabled=True`).
 
 ## Verification
 
@@ -314,22 +507,30 @@ System automatically detects single-tenant mode and uses orchestrator credential
 - Each tenant's resources stored in separate Table Storage partitions
 - Blob paths prefixed with tenant_id
 
-## Limitations (Phase 1 MVP)
+## Limitations
 
-### What's Supported
+### Phase 1 MVP - What's Supported
 
 - ✅ Single target tenant per execution
 - ✅ Explicit credential configuration via environment variables
 - ✅ Tenant-isolated storage and tracking
 - ✅ Full backward compatibility with single-tenant mode
 
+### Phase 2 - What's Supported
+
+- ✅ Multiple tenant configurations in Key Vault registry
+- ✅ Thread-safe credential caching per tenant
+- ✅ Programmatic tenant selection via `get_tenant_credential(config, tenant_id)`
+- ✅ Tenant enable/disable without removal
+- ✅ Prefix-based filtering for tenant discovery
+- ✅ 100% backward compatible with Phase 1
+
 ### What's NOT Supported (Deferred to Future Phases)
 
 - ❌ Multiple target tenants in one execution (fan-out)
 - ❌ CLI commands for tenant management
-- ❌ Automatic tenant discovery
+- ❌ Automatic tenant discovery from Azure
 - ❌ Meta-orchestrator (orchestrator of orchestrators)
-- ❌ Dynamic tenant selection at runtime
 
 ## Next Steps
 
@@ -371,5 +572,5 @@ For issues or questions:
 
 ---
 
-**Documentation Version**: Phase 1 MVP (Cross-Tenant Foundation)
-**Last Updated**: 2024-01-15
+**Documentation Version**: Phase 2 (Multi-Tenant Configuration Support)
+**Last Updated**: 2026-01-16

--- a/src/azure_haymaker/models/config.py
+++ b/src/azure_haymaker/models/config.py
@@ -7,6 +7,43 @@ from typing import Any
 from pydantic import BaseModel, Field, SecretStr, computed_field
 
 
+class TenantConfig(BaseModel):
+    """Configuration for a single tenant in multi-tenant deployments.
+
+    This model stores credentials and metadata for deploying scenarios
+    to a specific Azure tenant. Used by Phase 2+ multi-tenant support.
+
+    Example:
+        >>> tenant = TenantConfig(
+        ...     tenant_id="12345678-...",
+        ...     subscription_id="87654321-...",
+        ...     sp_client_id="client-id-...",
+        ...     sp_client_secret=SecretStr("secret"),
+        ...     display_name="Customer A"
+        ... )
+    """
+
+    tenant_id: str = Field(..., description="Azure AD tenant ID")
+    subscription_id: str = Field(..., description="Target subscription ID for deployments")
+    sp_client_id: str = Field(..., description="Service principal client ID for this tenant")
+    sp_client_secret: SecretStr = Field(..., description="Service principal secret for this tenant")
+    display_name: str | None = Field(
+        default=None, description="Human-readable name for this tenant"
+    )
+    enabled: bool = Field(default=True, description="Whether this tenant is active for deployments")
+    resource_group: str | None = Field(
+        default=None, description="Default resource group for deployments (optional)"
+    )
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def display(self) -> str:
+        """Get display string for logging (safe, no secrets)."""
+        name = self.display_name or f"tenant-{self.tenant_id[:8]}"
+        status = "enabled" if self.enabled else "disabled"
+        return f"{name} ({status})"
+
+
 class SimulationSize(str, Enum):
     """Simulation size determines how many scenarios to execute."""
 
@@ -149,6 +186,12 @@ class OrchestratorConfig(BaseModel):
         default=90, description="Maximum age of secrets before forced rotation", ge=1
     )
 
+    # Phase 2: Multi-tenant registry (optional - backward compatible)
+    tenants: dict[str, TenantConfig] = Field(
+        default_factory=dict,
+        description="Registry of configured tenants for multi-tenant deployments"
+    )
+
     @computed_field  # type: ignore[prop-decorator]
     @property
     def scenario_count(self) -> int:
@@ -184,6 +227,53 @@ class OrchestratorConfig(BaseModel):
         if self.is_cross_tenant:
             return f"{self.target_tenant_id[:8]}... (cross-tenant)"
         return f"{self.target_tenant_id[:8]}... (same as orchestrator)"
+
+    def get_tenant_config(self, tenant_id: str) -> TenantConfig | None:
+        """Get configuration for a specific tenant from the registry.
+
+        Args:
+            tenant_id: The Azure AD tenant ID to look up
+
+        Returns:
+            TenantConfig if found and enabled, None otherwise
+
+        Example:
+            >>> config = orchestrator_config.get_tenant_config("12345678-...")
+            >>> if config:
+            ...     print(f"Found tenant: {config.display}")
+        """
+        tenant = self.tenants.get(tenant_id)
+        if tenant and tenant.enabled:
+            return tenant
+        return None
+
+    def list_tenants(self, include_disabled: bool = False) -> list[TenantConfig]:
+        """List all configured tenants.
+
+        Args:
+            include_disabled: If True, include disabled tenants in the list
+
+        Returns:
+            List of TenantConfig objects
+
+        Example:
+            >>> tenants = orchestrator_config.list_tenants()
+            >>> for t in tenants:
+            ...     print(f"Tenant: {t.display}")
+        """
+        if include_disabled:
+            return list(self.tenants.values())
+        return [t for t in self.tenants.values() if t.enabled]
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def has_multi_tenant_registry(self) -> bool:
+        """Check if multi-tenant registry has any tenants configured.
+
+        Returns:
+            True if at least one tenant is configured in the registry
+        """
+        return len(self.tenants) > 0
 
     def model_post_init(self, __context: Any) -> None:
         """Post-initialization validation."""

--- a/src/azure_haymaker/orchestrator/config.py
+++ b/src/azure_haymaker/orchestrator/config.py
@@ -23,6 +23,7 @@ from azure_haymaker.models.config import (
     SimulationSize,
     StorageConfig,
     TableStorageConfig,
+    TenantConfig,
 )
 from azure_haymaker.orchestrator.config_env_loader import load_dotenv_with_warnings
 
@@ -286,3 +287,199 @@ async def load_config() -> OrchestratorConfig:
         ConfigurationError: If configuration loading fails
     """
     return await load_config_from_env_and_keyvault()
+
+
+def load_tenant_configs_from_keyvault(
+    kv_client: SecretClient,
+    prefix_filter: str | None = None
+) -> dict[str, TenantConfig]:
+    """Load tenant configurations from Key Vault (Phase 2 multi-tenant support).
+
+    Discovers and loads tenant configurations stored in Key Vault following
+    the naming convention:
+    - tenant-{prefix}-config: JSON with tenant_id, subscription_id, sp_client_id,
+                              display_name, enabled, resource_group
+    - tenant-{prefix}-secret: Service principal client secret
+
+    Args:
+        kv_client: Authenticated SecretClient for Key Vault
+        prefix_filter: Optional prefix to filter tenants (e.g., "prod" loads only
+                      tenant-prod-* secrets). If None, loads all tenant-*-config secrets.
+
+    Returns:
+        Dictionary mapping tenant_id to TenantConfig
+
+    Raises:
+        ConfigurationError: If a tenant config is malformed or missing required fields
+
+    Example:
+        >>> credential = DefaultAzureCredential()
+        >>> kv_client = SecretClient(vault_url="https://my-vault.vault.azure.net", credential=credential)
+        >>> tenants = load_tenant_configs_from_keyvault(kv_client)
+        >>> for tenant_id, config in tenants.items():
+        ...     print(f"Loaded tenant: {config.display}")
+
+    Key Vault Secret Format:
+        # tenant-customerA-config (JSON):
+        {
+            "tenant_id": "12345678-...",
+            "subscription_id": "87654321-...",
+            "sp_client_id": "abcdef12-...",
+            "display_name": "Customer A",
+            "enabled": true,
+            "resource_group": "rg-customerA"
+        }
+
+        # tenant-customerA-secret (plain text):
+        the-sp-client-secret-value
+    """
+    import json
+
+    tenants: dict[str, TenantConfig] = {}
+
+    try:
+        # List all secrets to find tenant configs
+        secret_properties = list(kv_client.list_properties_of_secrets())
+
+        # Find all tenant config secrets
+        config_secrets = []
+        for prop in secret_properties:
+            name = prop.name
+            if name and name.startswith("tenant-") and name.endswith("-config"):
+                # Extract prefix (e.g., "customerA" from "tenant-customerA-config")
+                prefix = name[7:-7]  # Strip "tenant-" and "-config"
+                if prefix_filter is None or prefix.startswith(prefix_filter):
+                    config_secrets.append((name, prefix))
+
+        logger.info(f"Found {len(config_secrets)} tenant config(s) in Key Vault")
+
+        # Load each tenant config
+        for config_name, prefix in config_secrets:
+            secret_name = f"tenant-{prefix}-secret"
+
+            try:
+                # Load config JSON
+                config_secret = kv_client.get_secret(config_name)
+                if not config_secret.value:
+                    logger.warning(f"Empty config secret: {config_name}, skipping")
+                    continue
+
+                config_data = json.loads(config_secret.value)
+
+                # Load SP secret
+                try:
+                    sp_secret = kv_client.get_secret(secret_name)
+                    if not sp_secret.value:
+                        raise ConfigurationError(
+                            f"Empty SP secret for tenant {prefix}: {secret_name}"
+                        )
+                except Exception as e:
+                    raise ConfigurationError(
+                        f"Failed to load SP secret for tenant {prefix}: {secret_name}. "
+                        f"Ensure the secret exists. Error: {e}"
+                    ) from e
+
+                # Validate required fields
+                required_fields = ["tenant_id", "subscription_id", "sp_client_id"]
+                missing = [f for f in required_fields if f not in config_data]
+                if missing:
+                    raise ConfigurationError(
+                        f"Tenant config {config_name} missing required fields: {missing}"
+                    )
+
+                # Build TenantConfig
+                tenant_config = TenantConfig(
+                    tenant_id=config_data["tenant_id"],
+                    subscription_id=config_data["subscription_id"],
+                    sp_client_id=config_data["sp_client_id"],
+                    sp_client_secret=SecretStr(sp_secret.value),
+                    display_name=config_data.get("display_name"),
+                    enabled=config_data.get("enabled", True),
+                    resource_group=config_data.get("resource_group"),
+                )
+
+                tenants[tenant_config.tenant_id] = tenant_config
+                logger.info(f"Loaded tenant config: {tenant_config.display}")
+
+            except json.JSONDecodeError as e:
+                raise ConfigurationError(
+                    f"Invalid JSON in tenant config {config_name}: {e}"
+                ) from e
+            except ValidationError as e:
+                raise ConfigurationError(
+                    f"Invalid tenant config {config_name}: {e}"
+                ) from e
+
+    except Exception as e:
+        if isinstance(e, ConfigurationError):
+            raise
+        raise ConfigurationError(
+            f"Failed to load tenant configs from Key Vault: {e}"
+        ) from e
+
+    return tenants
+
+
+async def load_config_with_tenants(
+    load_tenants_from_keyvault: bool = True,
+    tenant_prefix_filter: str | None = None
+) -> OrchestratorConfig:
+    """Load configuration with multi-tenant registry from Key Vault.
+
+    This is the recommended entry point for Phase 2+ deployments that need
+    multi-tenant support. It loads the base configuration and optionally
+    populates the tenant registry from Key Vault.
+
+    Args:
+        load_tenants_from_keyvault: If True, load tenant configs from Key Vault
+        tenant_prefix_filter: Optional prefix to filter tenant configs
+
+    Returns:
+        OrchestratorConfig with populated tenant registry
+
+    Raises:
+        ConfigurationError: If configuration loading fails
+
+    Example:
+        >>> config = await load_config_with_tenants()
+        >>> print(f"Loaded {len(config.tenants)} tenants")
+        >>> for tenant in config.list_tenants():
+        ...     print(f"  - {tenant.display}")
+    """
+    # Load base configuration
+    config = await load_config_from_env_and_keyvault()
+
+    if load_tenants_from_keyvault:
+        try:
+            credential = DefaultAzureCredential()
+            kv_client = SecretClient(
+                vault_url=config.key_vault_url,
+                credential=credential
+            )
+
+            tenants = load_tenant_configs_from_keyvault(
+                kv_client,
+                prefix_filter=tenant_prefix_filter
+            )
+
+            # Update config with loaded tenants
+            # Note: Pydantic models are immutable by default, so we create a new config
+            config_dict = config.model_dump()
+            config_dict["tenants"] = {
+                tid: t.model_dump() for tid, t in tenants.items()
+            }
+            config = OrchestratorConfig(**config_dict)
+
+            if tenants:
+                logger.info(
+                    f"Multi-tenant mode: loaded {len(tenants)} tenant(s) from Key Vault"
+                )
+
+        except Exception as e:
+            # Log warning but don't fail - tenants are optional
+            logger.warning(
+                f"Failed to load tenant configs from Key Vault: {e}. "
+                "Continuing without multi-tenant registry."
+            )
+
+    return config

--- a/src/azure_haymaker/utils/credentials.py
+++ b/src/azure_haymaker/utils/credentials.py
@@ -4,6 +4,9 @@ This module provides a singleton factory for Azure credentials to avoid
 redundant authentication overhead from creating new DefaultAzureCredential
 instances across the codebase.
 
+Phase 2 adds MultiTenantCredentialFactory for thread-safe credential caching
+per tenant in multi-tenant deployments.
+
 Usage:
     from azure_haymaker.utils.credentials import get_credential
 
@@ -16,6 +19,10 @@ Usage:
 
     # Force a new credential (rare use case)
     fresh_credential = AzureCredentialFactory.get_credential(force_refresh=True)
+
+    # Multi-tenant: Get credential for specific tenant
+    from azure_haymaker.utils.credentials import MultiTenantCredentialFactory
+    credential = MultiTenantCredentialFactory.get_credential_for_tenant(tenant_config)
 """
 
 import logging
@@ -26,7 +33,7 @@ from azure.identity import ClientSecretCredential, DefaultAzureCredential
 from azure.identity.aio import DefaultAzureCredential as AsyncDefaultAzureCredential
 
 if TYPE_CHECKING:
-    from azure_haymaker.models.config import OrchestratorConfig
+    from azure_haymaker.models.config import OrchestratorConfig, TenantConfig
 
 logger = logging.getLogger(__name__)
 
@@ -116,6 +123,98 @@ class AzureCredentialFactory:
             logger.debug("Credential cache cleared")
 
 
+class MultiTenantCredentialFactory:
+    """Thread-safe factory for cached credentials per tenant.
+
+    This class maintains a cache of ClientSecretCredential instances,
+    one per tenant. Credentials are created lazily and cached for reuse.
+    Thread-safe for concurrent access.
+
+    Phase 2 feature for multi-tenant deployments.
+
+    Example:
+        >>> from azure_haymaker.models.config import TenantConfig
+        >>> tenant = TenantConfig(
+        ...     tenant_id="12345678-...",
+        ...     subscription_id="...",
+        ...     sp_client_id="...",
+        ...     sp_client_secret=SecretStr("...")
+        ... )
+        >>> credential = MultiTenantCredentialFactory.get_credential_for_tenant(tenant)
+        >>> # Use credential for Azure SDK clients
+        >>> client = ResourceManagementClient(credential, tenant.subscription_id)
+    """
+
+    _credentials: dict[str, ClientSecretCredential] = {}
+    _lock: threading.Lock = threading.Lock()
+
+    @classmethod
+    def get_credential_for_tenant(
+        cls, tenant_config: "TenantConfig", force_refresh: bool = False
+    ) -> ClientSecretCredential:
+        """Get or create a cached credential for a specific tenant.
+
+        Args:
+            tenant_config: TenantConfig with credentials for the tenant
+            force_refresh: If True, create a new credential even if cached
+
+        Returns:
+            ClientSecretCredential for the tenant
+
+        Raises:
+            ValueError: If tenant_config is disabled
+
+        Example:
+            >>> credential = MultiTenantCredentialFactory.get_credential_for_tenant(tenant)
+        """
+        if not tenant_config.enabled:
+            raise ValueError(
+                f"Tenant {tenant_config.tenant_id[:8]}... is disabled. "
+                "Cannot create credential for disabled tenant."
+            )
+
+        tenant_id = tenant_config.tenant_id
+
+        with cls._lock:
+            if tenant_id not in cls._credentials or force_refresh:
+                logger.debug(
+                    f"Creating new ClientSecretCredential for tenant {tenant_id[:8]}..."
+                )
+                cls._credentials[tenant_id] = ClientSecretCredential(
+                    tenant_id=tenant_config.tenant_id,
+                    client_id=tenant_config.sp_client_id,
+                    client_secret=tenant_config.sp_client_secret.get_secret_value()
+                )
+            return cls._credentials[tenant_id]
+
+    @classmethod
+    def clear_cache(cls, tenant_id: str | None = None) -> None:
+        """Clear cached credentials.
+
+        Args:
+            tenant_id: If provided, clear only this tenant's credential.
+                      If None, clear all cached credentials.
+        """
+        with cls._lock:
+            if tenant_id:
+                if tenant_id in cls._credentials:
+                    del cls._credentials[tenant_id]
+                    logger.debug(f"Cleared credential cache for tenant {tenant_id[:8]}...")
+            else:
+                cls._credentials.clear()
+                logger.debug("Cleared all multi-tenant credential caches")
+
+    @classmethod
+    def get_cached_tenant_ids(cls) -> list[str]:
+        """Get list of tenant IDs with cached credentials.
+
+        Returns:
+            List of tenant IDs that have cached credentials
+        """
+        with cls._lock:
+            return list(cls._credentials.keys())
+
+
 def get_credential(force_refresh: bool = False) -> DefaultAzureCredential:
     """Convenience function to get cached Azure credential.
 
@@ -158,27 +257,60 @@ def get_async_credential(
     return AzureCredentialFactory.get_async_credential(force_refresh=force_refresh)
 
 
-def get_tenant_credential(config: "OrchestratorConfig") -> DefaultAzureCredential | ClientSecretCredential:
-    """Get credential for target tenant operations (cross-tenant aware).
+def get_tenant_credential(
+    config: "OrchestratorConfig",
+    tenant_id: str | None = None
+) -> DefaultAzureCredential | ClientSecretCredential:
+    """Get credential for target tenant operations (multi-tenant aware).
 
-    In cross-tenant mode: Returns ClientSecretCredential for target tenant
-    In single-tenant mode: Returns cached DefaultAzureCredential (backward compatible)
+    Priority order for credential selection:
+    1. If tenant_id provided and found in tenant registry -> use registry credential
+    2. If cross-tenant mode (Phase 1) -> use target_tenant_sp credentials
+    3. Single-tenant mode -> use cached DefaultAzureCredential
 
     Args:
         config: Orchestrator configuration with optional cross-tenant credentials
+        tenant_id: Optional specific tenant ID to get credential for.
+                  If provided, will check the tenant registry first.
 
     Returns:
         Credential instance appropriate for target tenant operations
 
     Raises:
-        ValueError: If cross-tenant mode enabled but credentials missing
+        ValueError: If cross-tenant mode enabled but credentials missing,
+                   or if tenant_id provided but not found in registry
 
     Example:
         >>> config = load_config()
+        >>> # Phase 1: Use target_tenant credentials
         >>> credential = get_tenant_credential(config)
-        >>> # Use credential for target tenant operations (SP creation, deployment)
+        >>>
+        >>> # Phase 2: Use specific tenant from registry
+        >>> credential = get_tenant_credential(config, tenant_id="12345678-...")
         >>> graph_client = GraphServiceClient(credential)
     """
+    # Phase 2: Check tenant registry first if tenant_id provided
+    if tenant_id:
+        tenant_config = config.get_tenant_config(tenant_id)
+        if tenant_config:
+            logger.debug(
+                f"Using multi-tenant registry credential for {tenant_config.display}"
+            )
+            return MultiTenantCredentialFactory.get_credential_for_tenant(tenant_config)
+        else:
+            # Check if tenant exists but is disabled
+            if tenant_id in config.tenants:
+                raise ValueError(
+                    f"Tenant {tenant_id[:8]}... is disabled in registry. "
+                    "Enable it or remove the tenant_id parameter."
+                )
+            # Tenant not in registry - fall through to Phase 1 logic
+            logger.debug(
+                f"Tenant {tenant_id[:8]}... not found in registry, "
+                "falling back to Phase 1 logic"
+            )
+
+    # Phase 1: Cross-tenant mode with explicit credentials
     if config.is_cross_tenant:
         # Validate cross-tenant credentials present
         if not config.target_tenant_sp_client_id:
@@ -210,6 +342,7 @@ def get_tenant_credential(config: "OrchestratorConfig") -> DefaultAzureCredentia
 
 __all__ = [
     "AzureCredentialFactory",
+    "MultiTenantCredentialFactory",
     "get_credential",
     "get_async_credential",
     "get_tenant_credential",

--- a/tests/unit/test_multi_tenant_config.py
+++ b/tests/unit/test_multi_tenant_config.py
@@ -1,0 +1,679 @@
+"""Unit tests for Phase 2 multi-tenant configuration support.
+
+This module tests:
+- TenantConfig model
+- OrchestratorConfig tenant registry methods
+- MultiTenantCredentialFactory
+- Key Vault loading (with mocked Key Vault client)
+- get_tenant_credential() with tenant_id parameter
+"""
+
+import json
+import os
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from azure_haymaker.models.config import (
+    CosmosDBConfig,
+    LogAnalyticsConfig,
+    OrchestratorConfig,
+    SimulationSize,
+    StorageConfig,
+    TableStorageConfig,
+    TenantConfig,
+)
+from azure_haymaker.utils.credentials import (
+    MultiTenantCredentialFactory,
+    get_tenant_credential,
+)
+
+
+def _create_test_config(**overrides):
+    """Helper function to create test configs with all required fields."""
+    defaults = {
+        "target_tenant_id": "orchestrator-tenant",
+        "target_subscription_id": "sub-123",
+        "main_sp_client_id": "sp",
+        "main_sp_client_secret": SecretStr("secret"),
+        "anthropic_api_key": SecretStr("test-anthropic-key"),
+        "service_bus_namespace": "test-servicebus",
+        "container_registry": "testreg.azurecr.io",
+        "container_image": "test:latest",
+        "key_vault_url": "https://test-kv.vault.azure.net/",
+        "simulation_size": SimulationSize.SMALL,
+        "storage": StorageConfig(
+            account_name="teststorage",
+            container_logs="logs",
+            container_state="state",
+            container_reports="reports",
+            container_scenarios="scenarios",
+        ),
+        "table_storage": TableStorageConfig(
+            account_name="testtablestorage",
+            table_execution_runs="executionruns",
+            table_scenario_status="scenariostatus",
+            table_resource_inventory="resourceinventory",
+        ),
+        "cosmosdb": CosmosDBConfig(
+            endpoint="https://test-cosmos.documents.azure.com:443/",
+            database_name="testdb",
+            container_metrics="metrics",
+        ),
+        "log_analytics": LogAnalyticsConfig(
+            workspace_id="test-workspace-id",
+            workspace_key=SecretStr("test-workspace-key"),
+        ),
+        "resource_group_name": "test-rg",
+        "vnet_integration_enabled": False,
+    }
+    defaults.update(overrides)
+    return OrchestratorConfig(**defaults)
+
+
+def _create_tenant_config(tenant_id: str, **overrides):
+    """Helper to create TenantConfig for testing."""
+    defaults = {
+        "tenant_id": tenant_id,
+        "subscription_id": f"sub-{tenant_id[:8]}",
+        "sp_client_id": f"sp-{tenant_id[:8]}",
+        "sp_client_secret": SecretStr(f"secret-{tenant_id[:8]}"),
+        "display_name": f"Test Tenant {tenant_id[:8]}",
+        "enabled": True,
+    }
+    defaults.update(overrides)
+    return TenantConfig(**defaults)
+
+
+# ============================================================================
+# TenantConfig Model Tests
+# ============================================================================
+
+
+class TestTenantConfigModel:
+    """Tests for TenantConfig model."""
+
+    def test_tenant_config_creation(self):
+        """Test basic TenantConfig creation."""
+        config = TenantConfig(
+            tenant_id="12345678-1234-1234-1234-123456789abc",
+            subscription_id="87654321-4321-4321-4321-cba987654321",
+            sp_client_id="abcdef12-3456-7890-abcd-ef1234567890",
+            sp_client_secret=SecretStr("test-secret"),
+        )
+
+        assert config.tenant_id == "12345678-1234-1234-1234-123456789abc"
+        assert config.subscription_id == "87654321-4321-4321-4321-cba987654321"
+        assert config.enabled is True  # Default
+        assert config.display_name is None  # Optional
+
+    def test_tenant_config_with_optional_fields(self):
+        """Test TenantConfig with all optional fields."""
+        config = TenantConfig(
+            tenant_id="12345678-1234-1234-1234-123456789abc",
+            subscription_id="87654321-4321-4321-4321-cba987654321",
+            sp_client_id="abcdef12-3456-7890-abcd-ef1234567890",
+            sp_client_secret=SecretStr("test-secret"),
+            display_name="Customer A",
+            enabled=False,
+            resource_group="rg-customer-a",
+        )
+
+        assert config.display_name == "Customer A"
+        assert config.enabled is False
+        assert config.resource_group == "rg-customer-a"
+
+    def test_tenant_config_display_property(self):
+        """Test display property for logging."""
+        config = TenantConfig(
+            tenant_id="12345678-1234-1234-1234-123456789abc",
+            subscription_id="sub-123",
+            sp_client_id="sp-123",
+            sp_client_secret=SecretStr("secret"),
+            display_name="Customer A",
+            enabled=True,
+        )
+
+        assert "Customer A" in config.display
+        assert "enabled" in config.display
+
+    def test_tenant_config_display_without_name(self):
+        """Test display property falls back to tenant_id prefix."""
+        config = TenantConfig(
+            tenant_id="12345678-1234-1234-1234-123456789abc",
+            subscription_id="sub-123",
+            sp_client_id="sp-123",
+            sp_client_secret=SecretStr("secret"),
+        )
+
+        assert "12345678" in config.display
+        assert "enabled" in config.display
+
+    def test_tenant_config_display_disabled(self):
+        """Test display shows disabled status."""
+        config = TenantConfig(
+            tenant_id="12345678-1234-1234-1234-123456789abc",
+            subscription_id="sub-123",
+            sp_client_id="sp-123",
+            sp_client_secret=SecretStr("secret"),
+            enabled=False,
+        )
+
+        assert "disabled" in config.display
+
+
+# ============================================================================
+# OrchestratorConfig Tenant Registry Tests
+# ============================================================================
+
+
+class TestOrchestratorConfigTenantRegistry:
+    """Tests for OrchestratorConfig tenant registry methods."""
+
+    def test_empty_tenant_registry_by_default(self):
+        """Test tenant registry is empty by default (backward compatible)."""
+        config = _create_test_config()
+
+        assert config.tenants == {}
+        assert not config.has_multi_tenant_registry
+        assert config.list_tenants() == []
+
+    def test_config_with_tenants(self):
+        """Test OrchestratorConfig with tenant registry."""
+        tenant_a = _create_tenant_config("tenant-a-12345678")
+        tenant_b = _create_tenant_config("tenant-b-87654321")
+
+        config = _create_test_config(
+            tenants={
+                tenant_a.tenant_id: tenant_a,
+                tenant_b.tenant_id: tenant_b,
+            }
+        )
+
+        assert config.has_multi_tenant_registry
+        assert len(config.tenants) == 2
+
+    def test_get_tenant_config_found(self):
+        """Test get_tenant_config returns tenant when found."""
+        tenant = _create_tenant_config("tenant-12345678")
+        config = _create_test_config(tenants={tenant.tenant_id: tenant})
+
+        result = config.get_tenant_config("tenant-12345678")
+
+        assert result is not None
+        assert result.tenant_id == "tenant-12345678"
+
+    def test_get_tenant_config_not_found(self):
+        """Test get_tenant_config returns None when not found."""
+        config = _create_test_config()
+
+        result = config.get_tenant_config("nonexistent-tenant")
+
+        assert result is None
+
+    def test_get_tenant_config_disabled(self):
+        """Test get_tenant_config returns None for disabled tenant."""
+        tenant = _create_tenant_config("tenant-12345678", enabled=False)
+        config = _create_test_config(tenants={tenant.tenant_id: tenant})
+
+        result = config.get_tenant_config("tenant-12345678")
+
+        assert result is None
+
+    def test_list_tenants_enabled_only(self):
+        """Test list_tenants returns only enabled tenants by default."""
+        tenant_a = _create_tenant_config("tenant-a", enabled=True)
+        tenant_b = _create_tenant_config("tenant-b", enabled=False)
+        tenant_c = _create_tenant_config("tenant-c", enabled=True)
+
+        config = _create_test_config(
+            tenants={
+                tenant_a.tenant_id: tenant_a,
+                tenant_b.tenant_id: tenant_b,
+                tenant_c.tenant_id: tenant_c,
+            }
+        )
+
+        result = config.list_tenants()
+
+        assert len(result) == 2
+        tenant_ids = [t.tenant_id for t in result]
+        assert "tenant-a" in tenant_ids
+        assert "tenant-c" in tenant_ids
+        assert "tenant-b" not in tenant_ids
+
+    def test_list_tenants_include_disabled(self):
+        """Test list_tenants can include disabled tenants."""
+        tenant_a = _create_tenant_config("tenant-a", enabled=True)
+        tenant_b = _create_tenant_config("tenant-b", enabled=False)
+
+        config = _create_test_config(
+            tenants={
+                tenant_a.tenant_id: tenant_a,
+                tenant_b.tenant_id: tenant_b,
+            }
+        )
+
+        result = config.list_tenants(include_disabled=True)
+
+        assert len(result) == 2
+
+
+# ============================================================================
+# MultiTenantCredentialFactory Tests
+# ============================================================================
+
+
+class TestMultiTenantCredentialFactory:
+    """Tests for MultiTenantCredentialFactory."""
+
+    def setup_method(self):
+        """Clear cache before each test."""
+        MultiTenantCredentialFactory.clear_cache()
+
+    def teardown_method(self):
+        """Clear cache after each test."""
+        MultiTenantCredentialFactory.clear_cache()
+
+    def test_get_credential_for_tenant(self):
+        """Test getting credential for a tenant."""
+        tenant = _create_tenant_config("tenant-12345678")
+
+        credential = MultiTenantCredentialFactory.get_credential_for_tenant(tenant)
+
+        from azure.identity import ClientSecretCredential
+
+        assert isinstance(credential, ClientSecretCredential)
+
+    def test_credential_caching(self):
+        """Test that credentials are cached."""
+        tenant = _create_tenant_config("tenant-12345678")
+
+        cred1 = MultiTenantCredentialFactory.get_credential_for_tenant(tenant)
+        cred2 = MultiTenantCredentialFactory.get_credential_for_tenant(tenant)
+
+        # Same object (cached)
+        assert cred1 is cred2
+
+    def test_credential_force_refresh(self):
+        """Test force_refresh creates new credential."""
+        tenant = _create_tenant_config("tenant-12345678")
+
+        cred1 = MultiTenantCredentialFactory.get_credential_for_tenant(tenant)
+        cred2 = MultiTenantCredentialFactory.get_credential_for_tenant(
+            tenant, force_refresh=True
+        )
+
+        # Different objects
+        assert cred1 is not cred2
+
+    def test_disabled_tenant_raises_error(self):
+        """Test getting credential for disabled tenant raises error."""
+        tenant = _create_tenant_config("tenant-12345678", enabled=False)
+
+        with pytest.raises(ValueError, match="disabled"):
+            MultiTenantCredentialFactory.get_credential_for_tenant(tenant)
+
+    def test_clear_cache_specific_tenant(self):
+        """Test clearing cache for specific tenant."""
+        tenant_a = _create_tenant_config("tenant-a")
+        tenant_b = _create_tenant_config("tenant-b")
+
+        MultiTenantCredentialFactory.get_credential_for_tenant(tenant_a)
+        MultiTenantCredentialFactory.get_credential_for_tenant(tenant_b)
+
+        assert len(MultiTenantCredentialFactory.get_cached_tenant_ids()) == 2
+
+        MultiTenantCredentialFactory.clear_cache("tenant-a")
+
+        cached = MultiTenantCredentialFactory.get_cached_tenant_ids()
+        assert "tenant-a" not in cached
+        assert "tenant-b" in cached
+
+    def test_clear_cache_all(self):
+        """Test clearing all cached credentials."""
+        tenant_a = _create_tenant_config("tenant-a")
+        tenant_b = _create_tenant_config("tenant-b")
+
+        MultiTenantCredentialFactory.get_credential_for_tenant(tenant_a)
+        MultiTenantCredentialFactory.get_credential_for_tenant(tenant_b)
+
+        MultiTenantCredentialFactory.clear_cache()
+
+        assert len(MultiTenantCredentialFactory.get_cached_tenant_ids()) == 0
+
+    def test_thread_safety(self):
+        """Test credential factory is thread-safe."""
+        tenant = _create_tenant_config("tenant-12345678")
+        credentials = []
+        errors = []
+
+        def get_credential():
+            try:
+                cred = MultiTenantCredentialFactory.get_credential_for_tenant(tenant)
+                credentials.append(cred)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=get_credential) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+        assert len(credentials) == 10
+        # All should be the same cached credential
+        assert all(c is credentials[0] for c in credentials)
+
+
+# ============================================================================
+# get_tenant_credential() Multi-Tenant Tests
+# ============================================================================
+
+
+class TestGetTenantCredentialMultiTenant:
+    """Tests for get_tenant_credential with tenant_id parameter."""
+
+    def setup_method(self):
+        """Clear cache before each test."""
+        MultiTenantCredentialFactory.clear_cache()
+
+    def teardown_method(self):
+        """Clear cache after each test."""
+        MultiTenantCredentialFactory.clear_cache()
+
+    def test_tenant_id_from_registry(self):
+        """Test get_tenant_credential uses registry when tenant_id provided."""
+        tenant = _create_tenant_config("tenant-12345678")
+        config = _create_test_config(tenants={tenant.tenant_id: tenant})
+
+        with patch.dict(os.environ, {"AZURE_TENANT_ID": "orchestrator-tenant"}):
+            credential = get_tenant_credential(config, tenant_id="tenant-12345678")
+
+        from azure.identity import ClientSecretCredential
+
+        assert isinstance(credential, ClientSecretCredential)
+
+    def test_tenant_id_disabled_raises_error(self):
+        """Test get_tenant_credential raises error for disabled tenant."""
+        tenant = _create_tenant_config("tenant-12345678", enabled=False)
+        config = _create_test_config(tenants={tenant.tenant_id: tenant})
+
+        with patch.dict(os.environ, {"AZURE_TENANT_ID": "orchestrator-tenant"}):
+            with pytest.raises(ValueError, match="disabled"):
+                get_tenant_credential(config, tenant_id="tenant-12345678")
+
+    def test_tenant_id_not_in_registry_falls_back(self):
+        """Test falls back to Phase 1 logic when tenant not in registry."""
+        config = _create_test_config(tenants={})
+
+        with patch("azure_haymaker.utils.credentials.get_credential") as mock_get_cred:
+            mock_cred = MagicMock()
+            mock_get_cred.return_value = mock_cred
+
+            with patch.dict(os.environ, {"AZURE_TENANT_ID": "orchestrator-tenant"}):
+                credential = get_tenant_credential(config, tenant_id="unknown-tenant")
+
+            # Falls back to single-tenant mode
+            mock_get_cred.assert_called_once()
+            assert credential == mock_cred
+
+    def test_backward_compatible_without_tenant_id(self):
+        """Test backward compatibility when no tenant_id provided."""
+        config = _create_test_config(tenants={})
+
+        with patch("azure_haymaker.utils.credentials.get_credential") as mock_get_cred:
+            mock_cred = MagicMock()
+            mock_get_cred.return_value = mock_cred
+
+            with patch.dict(os.environ, {"AZURE_TENANT_ID": "orchestrator-tenant"}):
+                credential = get_tenant_credential(config)
+
+            mock_get_cred.assert_called_once()
+            assert credential == mock_cred
+
+
+# ============================================================================
+# Key Vault Loading Tests
+# ============================================================================
+
+
+class TestLoadTenantConfigsFromKeyVault:
+    """Tests for load_tenant_configs_from_keyvault function."""
+
+    def test_load_tenant_configs_success(self):
+        """Test successful loading of tenant configs from Key Vault."""
+        from azure_haymaker.orchestrator.config import load_tenant_configs_from_keyvault
+
+        # Mock Key Vault client
+        mock_kv_client = MagicMock()
+
+        # Mock secret properties
+        mock_prop_a = MagicMock()
+        mock_prop_a.name = "tenant-customerA-config"
+        mock_prop_b = MagicMock()
+        mock_prop_b.name = "tenant-customerB-config"
+        mock_prop_other = MagicMock()
+        mock_prop_other.name = "other-secret"
+
+        mock_kv_client.list_properties_of_secrets.return_value = [
+            mock_prop_a,
+            mock_prop_b,
+            mock_prop_other,
+        ]
+
+        # Mock get_secret for configs and secrets
+        def mock_get_secret(name):
+            secrets = {
+                "tenant-customerA-config": MagicMock(
+                    value=json.dumps(
+                        {
+                            "tenant_id": "tenant-a-12345678",
+                            "subscription_id": "sub-a",
+                            "sp_client_id": "sp-a",
+                            "display_name": "Customer A",
+                        }
+                    )
+                ),
+                "tenant-customerA-secret": MagicMock(value="secret-a"),
+                "tenant-customerB-config": MagicMock(
+                    value=json.dumps(
+                        {
+                            "tenant_id": "tenant-b-87654321",
+                            "subscription_id": "sub-b",
+                            "sp_client_id": "sp-b",
+                        }
+                    )
+                ),
+                "tenant-customerB-secret": MagicMock(value="secret-b"),
+            }
+            return secrets.get(name)
+
+        mock_kv_client.get_secret = mock_get_secret
+
+        result = load_tenant_configs_from_keyvault(mock_kv_client)
+
+        assert len(result) == 2
+        assert "tenant-a-12345678" in result
+        assert "tenant-b-87654321" in result
+        assert result["tenant-a-12345678"].display_name == "Customer A"
+
+    def test_load_tenant_configs_with_prefix_filter(self):
+        """Test loading tenant configs with prefix filter."""
+        from azure_haymaker.orchestrator.config import load_tenant_configs_from_keyvault
+
+        mock_kv_client = MagicMock()
+
+        mock_prop_prod = MagicMock()
+        mock_prop_prod.name = "tenant-prod-customerA-config"
+        mock_prop_dev = MagicMock()
+        mock_prop_dev.name = "tenant-dev-customerB-config"
+
+        mock_kv_client.list_properties_of_secrets.return_value = [
+            mock_prop_prod,
+            mock_prop_dev,
+        ]
+
+        def mock_get_secret(name):
+            secrets = {
+                "tenant-prod-customerA-config": MagicMock(
+                    value=json.dumps(
+                        {
+                            "tenant_id": "prod-tenant",
+                            "subscription_id": "sub-prod",
+                            "sp_client_id": "sp-prod",
+                        }
+                    )
+                ),
+                "tenant-prod-customerA-secret": MagicMock(value="secret-prod"),
+            }
+            return secrets.get(name)
+
+        mock_kv_client.get_secret = mock_get_secret
+
+        result = load_tenant_configs_from_keyvault(
+            mock_kv_client, prefix_filter="prod"
+        )
+
+        assert len(result) == 1
+        assert "prod-tenant" in result
+
+    def test_load_tenant_configs_missing_secret_raises_error(self):
+        """Test error raised when SP secret is missing."""
+        from azure_haymaker.orchestrator.config import (
+            ConfigurationError,
+            load_tenant_configs_from_keyvault,
+        )
+
+        mock_kv_client = MagicMock()
+
+        mock_prop = MagicMock()
+        mock_prop.name = "tenant-test-config"
+        mock_kv_client.list_properties_of_secrets.return_value = [mock_prop]
+
+        def mock_get_secret(name):
+            if name == "tenant-test-config":
+                return MagicMock(
+                    value=json.dumps(
+                        {
+                            "tenant_id": "test-tenant",
+                            "subscription_id": "sub",
+                            "sp_client_id": "sp",
+                        }
+                    )
+                )
+            raise Exception("Secret not found")
+
+        mock_kv_client.get_secret = mock_get_secret
+
+        with pytest.raises(ConfigurationError, match="Failed to load SP secret"):
+            load_tenant_configs_from_keyvault(mock_kv_client)
+
+    def test_load_tenant_configs_invalid_json_raises_error(self):
+        """Test error raised when config JSON is invalid."""
+        from azure_haymaker.orchestrator.config import (
+            ConfigurationError,
+            load_tenant_configs_from_keyvault,
+        )
+
+        mock_kv_client = MagicMock()
+
+        mock_prop = MagicMock()
+        mock_prop.name = "tenant-test-config"
+        mock_kv_client.list_properties_of_secrets.return_value = [mock_prop]
+
+        mock_kv_client.get_secret.return_value = MagicMock(value="not-valid-json")
+
+        with pytest.raises(ConfigurationError, match="Invalid JSON"):
+            load_tenant_configs_from_keyvault(mock_kv_client)
+
+    def test_load_tenant_configs_missing_required_fields(self):
+        """Test error raised when required fields are missing."""
+        from azure_haymaker.orchestrator.config import (
+            ConfigurationError,
+            load_tenant_configs_from_keyvault,
+        )
+
+        mock_kv_client = MagicMock()
+
+        mock_prop = MagicMock()
+        mock_prop.name = "tenant-test-config"
+        mock_kv_client.list_properties_of_secrets.return_value = [mock_prop]
+
+        def mock_get_secret(name):
+            if name == "tenant-test-config":
+                return MagicMock(
+                    value=json.dumps(
+                        {
+                            "tenant_id": "test-tenant",
+                            # Missing: subscription_id, sp_client_id
+                        }
+                    )
+                )
+            return MagicMock(value="secret")
+
+        mock_kv_client.get_secret = mock_get_secret
+
+        with pytest.raises(ConfigurationError, match="missing required fields"):
+            load_tenant_configs_from_keyvault(mock_kv_client)
+
+
+# ============================================================================
+# Backward Compatibility Tests
+# ============================================================================
+
+
+class TestBackwardCompatibility:
+    """Tests ensuring Phase 2 is backward compatible with Phase 1."""
+
+    def setup_method(self):
+        """Clear cache before each test."""
+        MultiTenantCredentialFactory.clear_cache()
+
+    def teardown_method(self):
+        """Clear cache after each test."""
+        MultiTenantCredentialFactory.clear_cache()
+
+    def test_config_without_tenants_works(self):
+        """Test config without tenants field works (backward compatible)."""
+        config = _create_test_config()
+
+        assert not config.has_multi_tenant_registry
+        assert config.list_tenants() == []
+        assert config.get_tenant_config("any") is None
+
+    def test_phase1_cross_tenant_still_works(self):
+        """Test Phase 1 cross-tenant mode still works with Phase 2."""
+        with patch.dict(os.environ, {"AZURE_TENANT_ID": "orchestrator-tenant"}):
+            config = _create_test_config(
+                target_tenant_id="different-tenant",
+                target_tenant_sp_client_id="target-sp",
+                target_tenant_sp_client_secret=SecretStr("target-secret"),
+                tenants={},  # Empty registry
+            )
+
+            credential = get_tenant_credential(config)
+
+            from azure.identity import ClientSecretCredential
+
+            assert isinstance(credential, ClientSecretCredential)
+
+    def test_single_tenant_mode_unchanged(self):
+        """Test single-tenant mode behavior unchanged."""
+        with patch("azure_haymaker.utils.credentials.get_credential") as mock_get_cred:
+            mock_cred = MagicMock()
+            mock_get_cred.return_value = mock_cred
+
+            with patch.dict(os.environ, {"AZURE_TENANT_ID": "orchestrator-tenant"}):
+                config = _create_test_config(
+                    target_tenant_id="orchestrator-tenant",
+                    tenants={},
+                )
+
+                credential = get_tenant_credential(config)
+
+                mock_get_cred.assert_called_once()
+                assert credential == mock_cred


### PR DESCRIPTION
## Summary

- Add TenantConfig model for multi-tenant configuration
- Implement MultiTenantCredentialFactory for tenant-specific credentials
- Add Key Vault tenant loading for secure configuration
- Update documentation for Phase 2 cross-tenant setup

## Test plan

- [ ] Run unit tests: `pytest tests/unit/test_multi_tenant_config.py -v`
- [ ] Verify TenantConfig model validation
- [ ] Test credential factory with mock Key Vault

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)