### PR TITLE
docs: Add Phase 6 cross-tenant orchestration documentation (#213)

### DIFF
--- a/docs/cross-tenant/API.md
+++ b/docs/cross-tenant/API.md
@@ -1,0 +1,429 @@
+# Cross-Tenant API Reference
+
+This document describes the API endpoints for cross-tenant orchestration.
+
+## Authentication
+
+All API endpoints require authentication. Set the `Authorization` header:
+
+```bash
+curl -H "Authorization: Bearer <access_token>" https://your-orchestrator/api/...
+```
+
+Obtain tokens via Azure AD app registration or managed identity.
+
+## Base URL
+
+```
+https://haymaker-fastapi-app.azurewebsites.net
+```
+
+Or your custom orchestrator deployment URL.
+
+## Endpoints
+
+### Single-Tenant Execution
+
+#### POST /api/execute
+
+Trigger scenario execution in the configured target tenant.
+
+**Request:**
+
+```bash
+curl -X POST https://your-orchestrator/api/execute \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "skip_validation": false
+  }'
+```
+
+**Request Body (optional):**
+
+| Field | Type | Default | Description |
+|:------|:-----|:--------|:------------|
+| `skip_validation` | boolean | `false` | Skip environment validation |
+
+**Response:**
+
+```json
+{
+  "execution_id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "started",
+  "started_at": "2024-01-15T10:30:00Z",
+  "trace_id": "abc123def456"
+}
+```
+
+**Status Codes:**
+
+| Code | Description |
+|:-----|:------------|
+| 200 | Execution started |
+| 401 | Authentication required |
+| 500 | Server error |
+
+---
+
+### Multi-Tenant Execution
+
+#### POST /api/execute/multi-tenant
+
+Trigger scenario execution across all enabled tenants in the registry.
+
+**Request:**
+
+```bash
+curl -X POST https://your-orchestrator/api/execute/multi-tenant \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tenant_ids": ["tenant-id-1", "tenant-id-2"],
+    "scenarios": ["compute-01-linux-vm-web-server"],
+    "scenario_count": 5
+  }'
+```
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|:------|:-----|:---------|:------------|
+| `tenant_ids` | string[] | No | Specific tenants to target (default: all enabled) |
+| `scenarios` | string[] | No | Specific scenarios to run (default: random selection) |
+| `scenario_count` | integer | No | Number of scenarios per tenant (default: config value) |
+| `skip_validation` | boolean | No | Skip environment validation (default: false) |
+
+**Response:**
+
+```json
+{
+  "execution_id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "started",
+  "started_at": "2024-01-15T10:30:00Z",
+  "tenants": [
+    {
+      "tenant_id": "tenant-id-1",
+      "display_name": "Customer A",
+      "status": "pending"
+    },
+    {
+      "tenant_id": "tenant-id-2",
+      "display_name": "Customer B",
+      "status": "pending"
+    }
+  ]
+}
+```
+
+---
+
+### Execution Status
+
+#### GET /api/executions/{execution_id}
+
+Get status of an execution.
+
+**Request:**
+
+```bash
+curl https://your-orchestrator/api/executions/550e8400-e29b-41d4-a716-446655440000 \
+  -H "Authorization: Bearer <token>"
+```
+
+**Response:**
+
+```json
+{
+  "run_id": "550e8400-e29b-41d4-a716-446655440000",
+  "started_at": "2024-01-15T10:30:00Z",
+  "status": "running",
+  "phases": {
+    "validation": {
+      "status": "passed",
+      "checks": [...]
+    },
+    "selection": {
+      "status": "completed",
+      "scenario_count": 5,
+      "scenarios": ["compute-01-linux-vm-web-server", "databases-02-cosmos-db", ...]
+    },
+    "provisioning": {
+      "status": "completed",
+      "service_principals": {
+        "requested": 5,
+        "created": 5,
+        "failed": 0
+      },
+      "container_apps": {
+        "requested": 5,
+        "deployed": 5,
+        "failed": 0
+      }
+    },
+    "monitoring": {
+      "status_checks": [...],
+      "log_messages": 1250,
+      "resource_count": 23
+    }
+  },
+  "trace_id": "abc123def456"
+}
+```
+
+---
+
+#### GET /api/executions/{execution_id}/tenants
+
+Get per-tenant status for a multi-tenant execution.
+
+**Request:**
+
+```bash
+curl https://your-orchestrator/api/executions/550e8400-e29b-41d4-a716-446655440000/tenants \
+  -H "Authorization: Bearer <token>"
+```
+
+**Response:**
+
+```json
+{
+  "execution_id": "550e8400-e29b-41d4-a716-446655440000",
+  "tenants": [
+    {
+      "tenant_id": "12345678-1234-1234-1234-123456789abc",
+      "display_name": "Customer A",
+      "status": "completed",
+      "started_at": "2024-01-15T10:30:00Z",
+      "completed_at": "2024-01-15T18:45:00Z",
+      "scenarios_completed": 5,
+      "scenarios_failed": 0,
+      "resources_created": 15,
+      "resources_cleaned": 15
+    },
+    {
+      "tenant_id": "87654321-4321-4321-4321-cba987654321",
+      "display_name": "Customer B",
+      "status": "running",
+      "started_at": "2024-01-15T10:30:05Z",
+      "scenarios_completed": 3,
+      "scenarios_failed": 0,
+      "resources_created": 12
+    }
+  ]
+}
+```
+
+---
+
+### Tenant Management
+
+#### GET /api/tenants
+
+List all configured tenants.
+
+**Request:**
+
+```bash
+curl https://your-orchestrator/api/tenants \
+  -H "Authorization: Bearer <token>"
+```
+
+**Response:**
+
+```json
+{
+  "tenants": [
+    {
+      "tenant_id": "12345678-1234-1234-1234-123456789abc",
+      "display_name": "Customer A",
+      "subscription_id": "sub-id-1",
+      "enabled": true,
+      "resource_group": "rg-haymaker-customerA"
+    },
+    {
+      "tenant_id": "87654321-4321-4321-4321-cba987654321",
+      "display_name": "Customer B",
+      "subscription_id": "sub-id-2",
+      "enabled": true,
+      "resource_group": null
+    }
+  ],
+  "count": 2
+}
+```
+
+---
+
+### Cost and Resources
+
+#### GET /api/executions/{run_id}/cost
+
+Get cost summary for an execution.
+
+**Request:**
+
+```bash
+curl https://your-orchestrator/api/executions/550e8400-e29b-41d4-a716-446655440000/cost \
+  -H "Authorization: Bearer <token>"
+```
+
+**Response:**
+
+```json
+{
+  "run_id": "550e8400-e29b-41d4-a716-446655440000",
+  "total_cost_usd": 45.67,
+  "currency": "USD",
+  "period": {
+    "start": "2024-01-15T10:30:00Z",
+    "end": "2024-01-15T18:45:00Z"
+  },
+  "by_resource_type": {
+    "Microsoft.Compute/virtualMachines": 25.00,
+    "Microsoft.ContainerService/managedClusters": 15.00,
+    "Microsoft.Storage/storageAccounts": 5.67
+  },
+  "by_scenario": {
+    "compute-01-linux-vm-web-server": 12.50,
+    "containers-02-aks-cluster": 15.00,
+    "databases-02-cosmos-db": 18.17
+  },
+  "note": "Cost data may be delayed up to 24 hours"
+}
+```
+
+---
+
+#### GET /api/resources
+
+List HayMaker-managed resources.
+
+**Request:**
+
+```bash
+curl "https://your-orchestrator/api/resources?execution_id=550e8400-e29b-41d4-a716-446655440000" \
+  -H "Authorization: Bearer <token>"
+```
+
+**Query Parameters:**
+
+| Parameter | Type | Description |
+|:----------|:-----|:------------|
+| `execution_id` | string | Filter by execution ID |
+| `scenario` | string | Filter by scenario name |
+| `limit` | integer | Maximum results (default: 100) |
+
+**Response:**
+
+```json
+{
+  "resources": [
+    {
+      "id": "/subscriptions/.../resourceGroups/.../providers/Microsoft.Compute/virtualMachines/vm-haymaker-001",
+      "name": "vm-haymaker-001",
+      "type": "Microsoft.Compute/virtualMachines",
+      "resourceGroup": "rg-haymaker-scenario-001",
+      "location": "eastus",
+      "tags": {
+        "AzureHayMaker-managed": "true",
+        "RunId": "550e8400-e29b-41d4-a716-446655440000",
+        "Scenario": "compute-01-linux-vm-web-server"
+      }
+    }
+  ],
+  "count": 1,
+  "total_found": 23
+}
+```
+
+---
+
+## Error Responses
+
+All error responses follow this format:
+
+```json
+{
+  "detail": "Error message describing the problem"
+}
+```
+
+**Common Error Codes:**
+
+| Code | Description |
+|:-----|:------------|
+| 400 | Bad request (invalid parameters) |
+| 401 | Authentication required |
+| 403 | Forbidden (insufficient permissions) |
+| 404 | Resource not found |
+| 500 | Internal server error |
+
+**Example Error:**
+
+```json
+{
+  "detail": "Schedule not found: invalid-schedule-id"
+}
+```
+
+---
+
+## Rate Limiting
+
+The API implements rate limiting to prevent abuse:
+
+- **Default limit**: 100 requests per minute per client
+- **Execution endpoints**: 10 requests per minute
+
+Rate limit headers are included in responses:
+
+```
+X-RateLimit-Limit: 100
+X-RateLimit-Remaining: 95
+X-RateLimit-Reset: 1705323600
+```
+
+---
+
+## Webhooks
+
+Configure webhooks to receive execution notifications.
+
+### Webhook Events
+
+| Event | Description |
+|:------|:------------|
+| `execution.started` | Execution has started |
+| `execution.completed` | Execution completed successfully |
+| `execution.failed` | Execution failed |
+
+### Webhook Payload
+
+```json
+{
+  "event": "execution.completed",
+  "timestamp": "2024-01-15T18:45:00Z",
+  "data": {
+    "run_id": "550e8400-e29b-41d4-a716-446655440000",
+    "duration_hours": 8.25,
+    "scenarios_count": 5
+  }
+}
+```
+
+### Configure Webhooks
+
+Set the `WEBHOOK_URL` environment variable:
+
+```bash
+export WEBHOOK_URL="https://your-endpoint/webhooks/haymaker"
+```
+
+---
+
+## Related Documentation
+
+- [Architecture](./ARCHITECTURE.md) - System architecture
+- [Configuration](./CONFIGURATION.md) - Environment setup
+- [General API Reference](/AzureHayMaker/api) - Complete API documentation

--- a/docs/cross-tenant/ARCHITECTURE.md
+++ b/docs/cross-tenant/ARCHITECTURE.md
@@ -1,0 +1,227 @@
+# Cross-Tenant Architecture
+
+This document describes the architecture for Azure HayMaker cross-tenant orchestration.
+
+## Two-Tier Architecture
+
+Azure HayMaker cross-tenant orchestration uses a two-tier model:
+
+1. **Infrastructure Tenant** - Hosts the orchestrator service, secrets, and state
+2. **Target Tenant(s)** - Where scenarios deploy resources and generate telemetry
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           INFRASTRUCTURE TENANT                              │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────┐    │
+│  │                    Azure HayMaker Orchestrator                       │    │
+│  │              (FastAPI on App Service / Container App)                │    │
+│  │                                                                      │    │
+│  │  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐              │    │
+│  │  │   Scheduler  │  │  Execution   │  │   Cleanup    │              │    │
+│  │  │   (cron)     │  │   Manager    │  │   Manager    │              │    │
+│  │  └──────────────┘  └──────────────┘  └──────────────┘              │    │
+│  └────────────────────────────────┬────────────────────────────────────┘    │
+│                                   │                                          │
+│  ┌────────────┐  ┌────────────┐  │  ┌────────────┐  ┌────────────┐        │
+│  │ Key Vault  │  │   Table    │  │  │    Blob    │  │   Service  │        │
+│  │ (secrets)  │  │  Storage   │  │  │  Storage   │  │    Bus     │        │
+│  └────────────┘  └────────────┘  │  └────────────┘  └────────────┘        │
+│                                   │                                          │
+└───────────────────────────────────┼──────────────────────────────────────────┘
+                                    │
+            ┌───────────────────────┼───────────────────────┐
+            │ Cross-Tenant Auth     │                       │
+            │ (Service Principal)   │                       │
+            ▼                       ▼                       ▼
+┌─────────────────────┐  ┌─────────────────────┐  ┌─────────────────────┐
+│   TARGET TENANT A   │  │   TARGET TENANT B   │  │   TARGET TENANT C   │
+│                     │  │                     │  │                     │
+│  ┌──────────────┐   │  │  ┌──────────────┐   │  │  ┌──────────────┐   │
+│  │ Container    │   │  │  │ Container    │   │  │  │ Container    │   │
+│  │ Apps Env     │   │  │  │ Apps Env     │   │  │  │ Apps Env     │   │
+│  └──────┬───────┘   │  │  └──────┬───────┘   │  │  └──────┬───────┘   │
+│         │           │  │         │           │  │         │           │
+│  ┌──────▼───────┐   │  │  ┌──────▼───────┐   │  │  ┌──────▼───────┐   │
+│  │   Scenario   │   │  │  │   Scenario   │   │  │  │   Scenario   │   │
+│  │   Agents     │   │  │  │   Agents     │   │  │  │   Agents     │   │
+│  └──────────────┘   │  │  └──────────────┘   │  │  └──────────────┘   │
+│                     │  │                     │  │                     │
+│  Azure Resources:   │  │  Azure Resources:   │  │  Azure Resources:   │
+│  - VMs, AKS, etc.   │  │  - VMs, AKS, etc.   │  │  - VMs, AKS, etc.   │
+└─────────────────────┘  └─────────────────────┘  └─────────────────────┘
+```
+
+## Component Responsibilities
+
+### Infrastructure Tenant Components
+
+| Component | Responsibility |
+|:----------|:---------------|
+| **Orchestrator** | FastAPI service that schedules and coordinates executions |
+| **Key Vault** | Stores all secrets including target tenant SP credentials |
+| **Table Storage** | Execution state, schedule persistence, agent status |
+| **Blob Storage** | Execution reports, logs, scenario documents |
+| **Service Bus** | Event streaming from agents to orchestrator |
+
+### Target Tenant Components
+
+| Component | Responsibility |
+|:----------|:---------------|
+| **Container Apps Environment** | Hosts scenario agent containers |
+| **Scenario Agents** | Autonomous containers executing scenarios |
+| **Deployed Resources** | VMs, AKS clusters, databases created by scenarios |
+| **Ephemeral Service Principals** | Per-execution SPs for scenario resource access |
+
+## Authentication Flow
+
+### Cross-Tenant Service Principal Authentication
+
+```
+┌─────────────────┐                    ┌─────────────────┐
+│  Infrastructure │                    │  Target Tenant  │
+│     Tenant      │                    │                 │
+└────────┬────────┘                    └────────┬────────┘
+         │                                      │
+         │  1. Multi-tenant app registration    │
+         │─────────────────────────────────────>│
+         │                                      │
+         │  2. SP created in target tenant      │
+         │<─────────────────────────────────────│
+         │                                      │
+         │  3. Role assignments granted         │
+         │  (Contributor on subscription)       │
+         │<─────────────────────────────────────│
+         │                                      │
+         │  4. Orchestrator authenticates       │
+         │  with target tenant credentials      │
+         │─────────────────────────────────────>│
+         │                                      │
+         │  5. Deploy Container Apps + agents   │
+         │─────────────────────────────────────>│
+         │                                      │
+```
+
+### Credential Flow
+
+1. Orchestrator reads target tenant credentials from Key Vault
+2. Uses `ClientSecretCredential` with target tenant ID
+3. Authenticates to Azure Resource Manager in target tenant
+4. Deploys Container Apps Environment and scenario agents
+5. Each agent receives ephemeral SP credentials for its resources
+
+## Data Flow
+
+### Execution Lifecycle
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│                          ORCHESTRATOR (Infrastructure Tenant)             │
+│                                                                           │
+│  1. VALIDATION        2. SELECTION        3. PROVISIONING                 │
+│  ┌─────────────┐      ┌─────────────┐      ┌─────────────────────────┐   │
+│  │ Validate    │─────>│ Select      │─────>│ For each target tenant: │   │
+│  │ environment │      │ scenarios   │      │ - Create ephemeral SPs  │   │
+│  │ & config    │      │ based on    │      │ - Deploy container apps │   │
+│  │             │      │ size        │      │ - Start scenario agents │   │
+│  └─────────────┘      └─────────────┘      └─────────────────────────┘   │
+│                                                     │                      │
+│                                                     ▼                      │
+│  6. REPORTING         5. CLEANUP           4. MONITORING (8 hours)        │
+│  ┌─────────────┐      ┌─────────────┐      ┌─────────────────────────┐   │
+│  │ Generate    │<─────│ Verify      │<─────│ Poll container status   │   │
+│  │ reports     │      │ cleanup     │      │ Collect logs via        │   │
+│  │ Store to    │      │ Force delete│      │   Service Bus           │   │
+│  │ blob storage│      │ if needed   │      │ Track resource count    │   │
+│  └─────────────┘      └─────────────┘      └─────────────────────────┘   │
+│                                                                           │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+### Cross-Tenant Data Flow
+
+```
+Infrastructure Tenant                        Target Tenant
+┌──────────────────────┐                    ┌──────────────────────┐
+│                      │   ARM API Calls    │                      │
+│    Orchestrator      │───────────────────>│   Resource Manager   │
+│                      │                    │                      │
+│                      │   Container Logs   │                      │
+│    Service Bus   <───│────────────────────│   Scenario Agents    │
+│                      │                    │                      │
+│                      │   Metrics/Status   │                      │
+│    Table Storage <───│────────────────────│   Container Apps     │
+│                      │                    │                      │
+└──────────────────────┘                    └──────────────────────┘
+```
+
+## Multi-Tenant Registry
+
+For organizations managing multiple target tenants, the orchestrator maintains a tenant registry in Key Vault:
+
+```
+Key Vault Secrets:
+├── tenant-customerA-config     # JSON: {tenant_id, subscription_id, sp_client_id, ...}
+├── tenant-customerA-secret     # Plain text SP secret
+├── tenant-customerB-config
+├── tenant-customerB-secret
+├── tenant-prod-config
+├── tenant-prod-secret
+└── ...
+```
+
+### TenantConfig Model
+
+```python
+class TenantConfig:
+    tenant_id: str              # Azure AD tenant ID
+    subscription_id: str        # Target subscription ID
+    sp_client_id: str           # Service principal client ID
+    sp_client_secret: SecretStr # Service principal secret
+    display_name: str | None    # Human-readable name
+    enabled: bool               # Whether tenant is active
+    resource_group: str | None  # Default resource group
+```
+
+## Security Considerations
+
+### Isolation
+
+- Each target tenant operates independently
+- No cross-tenant data sharing between target tenants
+- Ephemeral service principals created per execution
+- All secrets stored in infrastructure tenant Key Vault
+
+### Least Privilege
+
+- Orchestrator SP: Only needs Container Apps Contributor in target tenant
+- Scenario SPs: Scoped to specific resource types needed
+- All SPs deleted after execution completes
+
+### Network Security
+
+- VNet integration available for Container Apps
+- Private endpoints supported for storage and Key Vault
+- Cross-tenant traffic uses Azure backbone (no public internet)
+
+## Scaling Considerations
+
+### Horizontal Scaling
+
+- Orchestrator is stateless (state in Table Storage)
+- Can run multiple orchestrator instances behind load balancer
+- Each target tenant execution is independent
+
+### Limits
+
+| Resource | Limit | Notes |
+|:---------|:------|:------|
+| Target tenants | No hard limit | Practical limit ~100 per orchestrator |
+| Concurrent executions per tenant | 10 | Configurable via rate limiter |
+| Scenarios per execution | 30 (large) | Configurable via simulation_size |
+
+## Related Documentation
+
+- [API Reference](./API.md) - Endpoint specifications
+- [Configuration Guide](./CONFIGURATION.md) - Setup and configuration
+- [Security Guide](/AzureHayMaker/security) - Security best practices

--- a/docs/cross-tenant/CONFIGURATION.md
+++ b/docs/cross-tenant/CONFIGURATION.md
@@ -1,0 +1,359 @@
+# Cross-Tenant Configuration Guide
+
+This guide covers configuring Azure HayMaker for cross-tenant and multi-tenant orchestration.
+
+## Configuration Methods
+
+Azure HayMaker configuration follows this priority order:
+
+1. **Environment variables** (highest priority)
+2. **Azure Key Vault secrets**
+3. **.env file** (local development only)
+
+## Single Cross-Tenant Setup
+
+For deploying to a single target tenant different from the orchestrator tenant.
+
+### Required Environment Variables
+
+```bash
+# Target tenant (where scenarios deploy)
+export AZURE_TENANT_ID="target-tenant-id"
+export AZURE_SUBSCRIPTION_ID="target-subscription-id"
+
+# Orchestrator service principal (in infrastructure tenant)
+export AZURE_CLIENT_ID="orchestrator-sp-client-id"
+
+# Cross-tenant credentials (SP in target tenant)
+export TARGET_TENANT_SP_CLIENT_ID="target-tenant-sp-client-id"
+export TARGET_TENANT_SP_CLIENT_SECRET="target-tenant-sp-secret"
+
+# Key Vault for additional secrets
+export KEY_VAULT_URL="https://haymaker-kv.vault.azure.net"
+
+# Azure services configuration
+export SERVICE_BUS_NAMESPACE="haymaker-sb.servicebus.windows.net"
+export CONTAINER_REGISTRY="haymakerregistry.azurecr.io"
+export CONTAINER_IMAGE="haymaker-agent:latest"
+export SIMULATION_SIZE="medium"  # small, medium, or large
+
+# Storage configuration
+export STORAGE_ACCOUNT_NAME="haymakerstorage"
+export TABLE_STORAGE_ACCOUNT_NAME="haymakertables"
+
+# Monitoring
+export LOG_ANALYTICS_WORKSPACE_ID="workspace-id"
+```
+
+### Key Vault Secrets
+
+These secrets must be stored in Key Vault:
+
+| Secret Name | Description |
+|:------------|:------------|
+| `main-sp-client-secret` | Orchestrator SP secret |
+| `anthropic-api-key` | Anthropic API key for Claude |
+| `log-analytics-workspace-key` | Log Analytics workspace key |
+| `target-tenant-{id}-sp-secret` | Target tenant SP secret (optional) |
+
+```bash
+# Store secrets in Key Vault
+az keyvault secret set \
+  --vault-name "haymaker-kv" \
+  --name "main-sp-client-secret" \
+  --value "your-sp-secret"
+
+az keyvault secret set \
+  --vault-name "haymaker-kv" \
+  --name "anthropic-api-key" \
+  --value "sk-ant-..."
+
+az keyvault secret set \
+  --vault-name "haymaker-kv" \
+  --name "log-analytics-workspace-key" \
+  --value "workspace-key-value"
+```
+
+## Multi-Tenant Setup
+
+For deploying to multiple target tenants from a single orchestrator.
+
+### Tenant Configuration in Key Vault
+
+Each target tenant requires two secrets following this naming convention:
+
+```
+tenant-{prefix}-config   # JSON configuration
+tenant-{prefix}-secret   # SP client secret
+```
+
+#### Config Secret Format
+
+```json
+{
+  "tenant_id": "12345678-1234-1234-1234-123456789abc",
+  "subscription_id": "87654321-4321-4321-4321-cba987654321",
+  "sp_client_id": "abcdef12-3456-7890-abcd-ef1234567890",
+  "display_name": "Customer A Production",
+  "enabled": true,
+  "resource_group": "rg-haymaker-customerA"
+}
+```
+
+#### Config Fields
+
+| Field | Required | Description |
+|:------|:---------|:------------|
+| `tenant_id` | Yes | Azure AD tenant ID |
+| `subscription_id` | Yes | Target subscription for deployments |
+| `sp_client_id` | Yes | Service principal client ID in this tenant |
+| `display_name` | No | Human-readable name (default: tenant-{id}) |
+| `enabled` | No | Whether tenant is active (default: true) |
+| `resource_group` | No | Default resource group for deployments |
+
+### Adding Tenant Configurations
+
+```bash
+# Add Customer A tenant
+az keyvault secret set \
+  --vault-name "haymaker-kv" \
+  --name "tenant-customerA-config" \
+  --value '{
+    "tenant_id": "12345678-1234-1234-1234-123456789abc",
+    "subscription_id": "sub-customerA-001",
+    "sp_client_id": "sp-customerA-client-id",
+    "display_name": "Customer A Production",
+    "enabled": true,
+    "resource_group": "rg-haymaker"
+  }'
+
+az keyvault secret set \
+  --vault-name "haymaker-kv" \
+  --name "tenant-customerA-secret" \
+  --value "customer-A-sp-secret-value"
+
+# Add Customer B tenant
+az keyvault secret set \
+  --vault-name "haymaker-kv" \
+  --name "tenant-customerB-config" \
+  --value '{
+    "tenant_id": "87654321-4321-4321-4321-cba987654321",
+    "subscription_id": "sub-customerB-001",
+    "sp_client_id": "sp-customerB-client-id",
+    "display_name": "Customer B Staging",
+    "enabled": true
+  }'
+
+az keyvault secret set \
+  --vault-name "haymaker-kv" \
+  --name "tenant-customerB-secret" \
+  --value "customer-B-sp-secret-value"
+```
+
+### Filtering Tenants
+
+Use prefix filtering to load subsets of tenants:
+
+```bash
+# Load only production tenants (tenant-prod-*)
+export TENANT_PREFIX_FILTER="prod"
+
+# Load only customer tenants (tenant-customer-*)
+export TENANT_PREFIX_FILTER="customer"
+```
+
+## Service Principal Setup
+
+### Creating Cross-Tenant Service Principal
+
+1. **Register multi-tenant app in infrastructure tenant:**
+
+```bash
+# Create multi-tenant app registration
+az ad app create \
+  --display-name "HayMaker Cross-Tenant" \
+  --sign-in-audience "AzureADMultipleOrgs"
+```
+
+2. **Create service principal in target tenant:**
+
+In target tenant, have an admin consent to the app:
+
+```
+https://login.microsoftonline.com/{target-tenant-id}/adminconsent?client_id={app-id}
+```
+
+3. **Grant permissions in target tenant:**
+
+```bash
+# Switch to target tenant context
+az login --tenant "target-tenant-id"
+
+# Get the SP object ID in target tenant
+SP_OBJECT_ID=$(az ad sp show --id "app-id" --query id -o tsv)
+
+# Assign Contributor role on subscription
+az role assignment create \
+  --assignee-object-id "$SP_OBJECT_ID" \
+  --assignee-principal-type ServicePrincipal \
+  --role "Contributor" \
+  --scope "/subscriptions/{subscription-id}"
+```
+
+### Required Permissions
+
+| Permission | Scope | Purpose |
+|:-----------|:------|:--------|
+| Contributor | Subscription | Deploy Container Apps and resources |
+| User Access Administrator | Subscription | Create ephemeral SPs for scenarios |
+| Key Vault Secrets Officer | Key Vault | Store ephemeral SP secrets |
+
+## VNet Configuration
+
+For secure deployments, configure VNet integration:
+
+```bash
+export VNET_INTEGRATION_ENABLED="true"
+export VNET_RESOURCE_GROUP="rg-networking"
+export VNET_NAME="vnet-haymaker"
+export SUBNET_NAME="subnet-containers"
+```
+
+### VNet Requirements
+
+- Subnet must be delegated to Container Apps
+- Minimum /23 CIDR for Container Apps Environment
+- NSG rules allowing outbound to Azure services
+
+## Simulation Size
+
+Control how many scenarios run per execution:
+
+| Size | Scenario Count | Use Case |
+|:-----|:---------------|:---------|
+| `small` | 5 | Development, testing |
+| `medium` | 15 | Standard operations |
+| `large` | 30 | Full simulation |
+
+```bash
+export SIMULATION_SIZE="medium"
+```
+
+## Optional Configuration
+
+### Container Configuration
+
+```bash
+export CONTAINER_MEMORY_GB="64"      # Default: 64
+export CONTAINER_CPU_CORES="2"       # Default: 2
+export CONTAINER_TIMEOUT_HOURS="10"  # Default: 10
+export EXECUTION_DURATION_HOURS="8"  # Default: 8
+```
+
+### Service Principal Rotation
+
+```bash
+export SP_SECRET_ROTATION_DAYS="30"           # Days between rotations
+export SP_SECRET_EXPIRATION_WARNING_DAYS="7"  # Warning before expiration
+export SP_SECRET_AUTO_ROTATE="true"           # Enable auto-rotation
+export SP_SECRET_MAX_AGE_DAYS="90"            # Force rotation after 90 days
+```
+
+### Webhooks
+
+```bash
+export WEBHOOK_URL="https://your-endpoint/webhooks/haymaker"
+```
+
+## Complete Example Configuration
+
+### Infrastructure Tenant .env
+
+```bash
+# Infrastructure tenant identity
+AZURE_CLIENT_ID=orchestrator-sp-client-id
+
+# Target tenant (default)
+AZURE_TENANT_ID=target-tenant-id
+AZURE_SUBSCRIPTION_ID=target-subscription-id
+
+# Cross-tenant SP (optional, for single cross-tenant)
+TARGET_TENANT_SP_CLIENT_ID=target-sp-client-id
+TARGET_TENANT_SP_CLIENT_SECRET=target-sp-secret
+
+# Key Vault
+KEY_VAULT_URL=https://haymaker-kv.vault.azure.net
+
+# Azure Services
+SERVICE_BUS_NAMESPACE=haymaker-sb.servicebus.windows.net
+SERVICE_BUS_TOPIC=agent-logs
+CONTAINER_REGISTRY=haymakerregistry.azurecr.io
+CONTAINER_IMAGE=haymaker-agent:latest
+
+# Simulation
+SIMULATION_SIZE=medium
+RESOURCE_GROUP_NAME=azure-haymaker-rg
+
+# Storage
+STORAGE_ACCOUNT_NAME=haymakerstorage
+TABLE_STORAGE_ACCOUNT_NAME=haymakertables
+COSMOSDB_ENDPOINT=https://haymaker-cosmos.documents.azure.com:443/
+COSMOSDB_DATABASE=haymaker
+
+# Monitoring
+LOG_ANALYTICS_WORKSPACE_ID=workspace-guid
+
+# VNet (optional)
+VNET_INTEGRATION_ENABLED=false
+```
+
+## Validation
+
+Verify configuration using the validate endpoint:
+
+```bash
+curl -X POST https://your-orchestrator/api/validate \
+  -H "Authorization: Bearer <token>"
+```
+
+**Response:**
+
+```json
+{
+  "overall_passed": true,
+  "results": [
+    {"check": "key_vault_access", "passed": true},
+    {"check": "target_tenant_auth", "passed": true},
+    {"check": "container_registry_access", "passed": true},
+    {"check": "storage_access", "passed": true}
+  ]
+}
+```
+
+## Troubleshooting
+
+### Common Issues
+
+| Issue | Cause | Solution |
+|:------|:------|:---------|
+| "Target tenant SP secret not found" | Missing Key Vault secret | Add `target-tenant-{id}-sp-secret` to Key Vault |
+| "Cross-tenant mode enabled but no SP" | Missing `TARGET_TENANT_SP_CLIENT_ID` | Set environment variable or add to Key Vault |
+| "Key Vault access denied" | Orchestrator lacks permissions | Grant "Key Vault Secrets User" role |
+| "VNet integration enabled but config missing" | Incomplete VNet config | Set all VNet variables or disable integration |
+
+### Verify Cross-Tenant Mode
+
+Check if cross-tenant mode is active:
+
+```bash
+curl https://your-orchestrator/api/status \
+  -H "Authorization: Bearer <token>"
+```
+
+Look for `mode: "cross-tenant"` in the response.
+
+## Related Documentation
+
+- [Architecture](./ARCHITECTURE.md) - System architecture
+- [API Reference](./API.md) - Endpoint specifications
+- [Security Guide](/AzureHayMaker/security) - Security best practices

--- a/docs/cross-tenant/README.md
+++ b/docs/cross-tenant/README.md
@@ -1,0 +1,125 @@
+# Cross-Tenant Orchestration
+
+Deploy Azure HayMaker scenarios across multiple Azure tenants from a single infrastructure tenant.
+
+## Overview
+
+Cross-tenant orchestration enables a central orchestrator in an "infrastructure tenant" to deploy and manage scenarios in one or more "target tenants." This is useful for:
+
+- **Managed service providers (MSPs)** running simulations across customer tenants
+- **Large enterprises** with multiple Azure AD tenants
+- **Security teams** testing detection across isolated environments
+
+## When to Use
+
+| Scenario | Recommended Mode |
+|:---------|:-----------------|
+| Single organization, one tenant | Single-tenant (default) |
+| MSP managing multiple customers | Multi-tenant orchestration |
+| Enterprise with dev/staging/prod tenants | Multi-tenant orchestration |
+| Security team testing cross-boundary detection | Cross-tenant mode |
+
+## Quick Start
+
+### Prerequisites
+
+- Azure HayMaker orchestrator deployed in infrastructure tenant
+- Service principal with permissions in target tenant
+- Target tenant SP credentials stored in Key Vault
+
+### 1. Configure Target Tenant Credentials
+
+Set environment variables or store in Key Vault:
+
+```bash
+# Environment variables (for single target tenant)
+export TARGET_TENANT_SP_CLIENT_ID="your-target-sp-client-id"
+export TARGET_TENANT_SP_CLIENT_SECRET="your-target-sp-secret"
+export AZURE_TENANT_ID="target-tenant-id"
+export AZURE_SUBSCRIPTION_ID="target-subscription-id"
+```
+
+Or store in Key Vault for multi-tenant:
+
+```bash
+# Key Vault secret naming convention
+# tenant-{prefix}-config: JSON with tenant metadata
+# tenant-{prefix}-secret: SP client secret
+
+az keyvault secret set \
+  --vault-name "haymaker-kv" \
+  --name "tenant-customerA-config" \
+  --value '{"tenant_id":"...", "subscription_id":"...", "sp_client_id":"...", "display_name":"Customer A", "enabled":true}'
+
+az keyvault secret set \
+  --vault-name "haymaker-kv" \
+  --name "tenant-customerA-secret" \
+  --value "sp-client-secret-value"
+```
+
+### 2. Execute Scenarios
+
+Single target tenant:
+
+```bash
+curl -X POST https://your-orchestrator/api/execute \
+  -H "Content-Type: application/json" \
+  -d '{"scenarios": ["compute-01-linux-vm-web-server"]}'
+```
+
+Multi-tenant (when Key Vault tenants are configured):
+
+```bash
+curl -X POST https://your-orchestrator/api/execute/multi-tenant \
+  -H "Content-Type: application/json" \
+  -d '{"scenarios": ["compute-01-linux-vm-web-server"]}'
+```
+
+### 3. Monitor Execution
+
+```bash
+# Get execution status
+curl https://your-orchestrator/api/executions/{execution_id}
+
+# Get per-tenant status (multi-tenant)
+curl https://your-orchestrator/api/executions/{execution_id}/tenants
+```
+
+## Architecture
+
+```
+Infrastructure Tenant                    Target Tenant(s)
+┌─────────────────────────┐             ┌─────────────────────────┐
+│  HayMaker Orchestrator  │             │   Deployed Resources    │
+│  - FastAPI Service      │────────────>│   - Container Apps      │
+│  - Key Vault (secrets)  │  Cross-     │   - Service Principals  │
+│  - Table Storage        │  Tenant     │   - Scenario Resources  │
+│  - Blob Storage         │  Auth       │                         │
+└─────────────────────────┘             └─────────────────────────┘
+```
+
+See [Architecture Documentation](./ARCHITECTURE.md) for detailed diagrams and component descriptions.
+
+## Configuration Reference
+
+| Variable | Required | Description |
+|:---------|:---------|:------------|
+| `AZURE_TENANT_ID` | Yes | Target tenant ID |
+| `AZURE_SUBSCRIPTION_ID` | Yes | Target subscription ID |
+| `TARGET_TENANT_SP_CLIENT_ID` | Cross-tenant | SP client ID in target tenant |
+| `TARGET_TENANT_SP_CLIENT_SECRET` | Cross-tenant | SP secret for target tenant |
+| `KEY_VAULT_URL` | Yes | Key Vault URL for secrets |
+
+See [Configuration Guide](./CONFIGURATION.md) for complete reference.
+
+## Documentation
+
+- [Architecture](./ARCHITECTURE.md) - Two-tier architecture and data flow
+- [API Reference](./API.md) - Endpoint specifications and examples
+- [Configuration](./CONFIGURATION.md) - Environment variables and Key Vault setup
+
+## Related Documentation
+
+- [Deployment Guide](/AzureHayMaker/deployment) - Initial orchestrator deployment
+- [Security Guide](/AzureHayMaker/security) - Authentication and authorization
+- [API Reference](/AzureHayMaker/api) - Complete API documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -249,6 +249,7 @@ Task-focused guides for specific operations:
 
 - [Configure Anthropic Model](/AzureHayMaker/howto/configure-anthropic-model) - Select and configure Claude models for AI email generation
 - [GitOps Deployment](/AzureHayMaker/gitops-deployment) - Fully automated deployment with secret injection and verification
+- [Cross-Tenant Orchestration](/AzureHayMaker/cross-tenant/) - Deploy scenarios across multiple Azure tenants
 
 ---
 


### PR DESCRIPTION
## Summary

- Creates `docs/cross-tenant/README.md` - Overview and quick start guide
- Creates `docs/cross-tenant/ARCHITECTURE.md` - Two-tier architecture with ASCII diagrams
- Creates `docs/cross-tenant/API.md` - API reference with request/response examples
- Creates `docs/cross-tenant/CONFIGURATION.md` - Environment variables and Key Vault setup
- Updates `docs/index.md` to link to cross-tenant documentation

**Phase 6 of 6** in cross-tenant orchestration (Issue #147).

**Total**: 1140 lines of documentation.

## Test plan

- [ ] Verify all markdown files render correctly
- [ ] Verify links in index.md work
- [ ] Verify ASCII diagrams display properly
- [ ] Review API examples for accuracy

## Related

- Part of: #147 (Cross-Tenant Orchestration)
- Closes: #213
- Depends on: PR #212 (Phase 5 Testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)