### PR TITLE
refactor: consolidate duplicate exception classes to central module

### DIFF
--- a/src/azure_haymaker/orchestrator/__init__.py
+++ b/src/azure_haymaker/orchestrator/__init__.py
@@ -35,11 +35,13 @@ Module Structure:
 - meta_orchestrator.py: Multi-tenant parallel execution (Phase 3)
 """
 
+from azure_haymaker.exceptions import ContainerError as ContainerAppError
+from azure_haymaker.exceptions import ServicePrincipalError
+
 from . import activities  # noqa: F401
 from .container_deployer import ContainerDeployer
 from .container_lifecycle import ContainerLifecycle, delete_container_app
 from .container_manager import (
-    ContainerAppError,
     ContainerManager,
     ImageSigningError,
     deploy_container_app,
@@ -69,7 +71,6 @@ from .scenario_selector import (
 )
 from .sp_manager import (
     ServicePrincipalDetails,
-    ServicePrincipalError,
     create_service_principal,
     delete_service_principal,
     list_haymaker_service_principals,

--- a/src/azure_haymaker/orchestrator/config.py
+++ b/src/azure_haymaker/orchestrator/config.py
@@ -16,6 +16,7 @@ from azure.identity import DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient
 from pydantic import SecretStr, ValidationError
 
+from azure_haymaker.exceptions import ConfigurationError
 from azure_haymaker.models.config import (
     CosmosDBConfig,
     LogAnalyticsConfig,
@@ -28,12 +29,6 @@ from azure_haymaker.models.config import (
 from azure_haymaker.orchestrator.config_env_loader import load_dotenv_with_warnings
 
 logger = logging.getLogger(__name__)
-
-
-class ConfigurationError(Exception):
-    """Raised when configuration is invalid or missing."""
-
-    pass
 
 
 def _get_required_env(var_name: str, dotenv_vars: dict[str, str] | None = None) -> str:
@@ -188,8 +183,11 @@ async def load_config_from_env_and_keyvault() -> OrchestratorConfig:
                     log_analytics_key = kv_client.get_secret("log-analytics-workspace-key").value
 
                 # Try loading cross-tenant secret if target tenant differs and ID provided
-                if (not target_tenant_sp_secret and target_tenant_sp_id
-                    and target_tenant_id != os.getenv("AZURE_TENANT_ID", "")):
+                if (
+                    not target_tenant_sp_secret
+                    and target_tenant_sp_id
+                    and target_tenant_id != os.getenv("AZURE_TENANT_ID", "")
+                ):
                     secret_name = f"target-tenant-{target_tenant_id[:8]}-sp-secret"
                     try:
                         target_tenant_sp_secret = kv_client.get_secret(secret_name).value
@@ -214,7 +212,9 @@ async def load_config_from_env_and_keyvault() -> OrchestratorConfig:
                 main_sp_client_id=main_sp_client_id,
                 main_sp_client_secret=SecretStr(main_sp_secret),
                 target_tenant_sp_client_id=target_tenant_sp_id,
-                target_tenant_sp_client_secret=SecretStr(target_tenant_sp_secret) if target_tenant_sp_secret else None,
+                target_tenant_sp_client_secret=SecretStr(target_tenant_sp_secret)
+                if target_tenant_sp_secret
+                else None,
                 anthropic_api_key=SecretStr(anthropic_api_key),
                 service_bus_namespace=service_bus_namespace,
                 service_bus_topic=service_bus_topic,
@@ -290,8 +290,7 @@ async def load_config() -> OrchestratorConfig:
 
 
 def load_tenant_configs_from_keyvault(
-    kv_client: SecretClient,
-    prefix_filter: str | None = None
+    kv_client: SecretClient, prefix_filter: str | None = None
 ) -> dict[str, TenantConfig]:
     """Load tenant configurations from Key Vault (Phase 2 multi-tenant support).
 
@@ -402,27 +401,20 @@ def load_tenant_configs_from_keyvault(
                 logger.info(f"Loaded tenant config: {tenant_config.display}")
 
             except json.JSONDecodeError as e:
-                raise ConfigurationError(
-                    f"Invalid JSON in tenant config {config_name}: {e}"
-                ) from e
+                raise ConfigurationError(f"Invalid JSON in tenant config {config_name}: {e}") from e
             except ValidationError as e:
-                raise ConfigurationError(
-                    f"Invalid tenant config {config_name}: {e}"
-                ) from e
+                raise ConfigurationError(f"Invalid tenant config {config_name}: {e}") from e
 
     except Exception as e:
         if isinstance(e, ConfigurationError):
             raise
-        raise ConfigurationError(
-            f"Failed to load tenant configs from Key Vault: {e}"
-        ) from e
+        raise ConfigurationError(f"Failed to load tenant configs from Key Vault: {e}") from e
 
     return tenants
 
 
 async def load_config_with_tenants(
-    load_tenants_from_keyvault: bool = True,
-    tenant_prefix_filter: str | None = None
+    load_tenants_from_keyvault: bool = True, tenant_prefix_filter: str | None = None
 ) -> OrchestratorConfig:
     """Load configuration with multi-tenant registry from Key Vault.
 
@@ -452,28 +444,20 @@ async def load_config_with_tenants(
     if load_tenants_from_keyvault:
         try:
             credential = DefaultAzureCredential()
-            kv_client = SecretClient(
-                vault_url=config.key_vault_url,
-                credential=credential
-            )
+            kv_client = SecretClient(vault_url=config.key_vault_url, credential=credential)
 
             tenants = load_tenant_configs_from_keyvault(
-                kv_client,
-                prefix_filter=tenant_prefix_filter
+                kv_client, prefix_filter=tenant_prefix_filter
             )
 
             # Update config with loaded tenants
             # Note: Pydantic models are immutable by default, so we create a new config
             config_dict = config.model_dump()
-            config_dict["tenants"] = {
-                tid: t.model_dump() for tid, t in tenants.items()
-            }
+            config_dict["tenants"] = {tid: t.model_dump() for tid, t in tenants.items()}
             config = OrchestratorConfig(**config_dict)
 
             if tenants:
-                logger.info(
-                    f"Multi-tenant mode: loaded {len(tenants)} tenant(s) from Key Vault"
-                )
+                logger.info(f"Multi-tenant mode: loaded {len(tenants)} tenant(s) from Key Vault")
 
         except Exception as e:
             # Log warning but don't fail - tenants are optional

--- a/src/azure_haymaker/orchestrator/container_deployer.py
+++ b/src/azure_haymaker/orchestrator/container_deployer.py
@@ -8,6 +8,7 @@ import asyncio
 import logging
 from typing import Any
 
+from azure_haymaker.exceptions import ContainerError
 from azure_haymaker.models.config import OrchestratorConfig
 from azure_haymaker.models.scenario import ScenarioMetadata
 from azure_haymaker.models.service_principal import ServicePrincipalDetails
@@ -15,11 +16,8 @@ from azure_haymaker.models.service_principal import ServicePrincipalDetails
 # Configure logging
 logger = logging.getLogger(__name__)
 
-
-class ContainerAppError(Exception):
-    """Raised when container app operations fail."""
-
-    pass
+# Backward compatibility alias - use ContainerError from central exceptions
+ContainerAppError = ContainerError
 
 
 class ContainerDeployer:
@@ -99,8 +97,8 @@ class ContainerDeployer:
                     "target_tenant": self.config.target_tenant_id[:8] + "...",
                     "target_subscription": self.config.target_subscription_id,
                     "resource_group": self.config.resource_group_name,
-                    "mode": "cross-tenant" if self.config.is_cross_tenant else "single-tenant"
-                }
+                    "mode": "cross-tenant" if self.config.is_cross_tenant else "single-tenant",
+                },
             )
 
             # Build container configuration
@@ -194,7 +192,9 @@ class ContainerDeployer:
 
                 # Set TARGET_TENANT_SP_SECRET in environment for shell expansion
                 login_env = os.environ.copy()
-                login_env["TARGET_TENANT_SP_SECRET"] = self.config.target_tenant_sp_client_secret.get_secret_value()
+                login_env["TARGET_TENANT_SP_SECRET"] = (
+                    self.config.target_tenant_sp_client_secret.get_secret_value()
+                )
             else:
                 # Single-tenant mode: Use orchestrator credentials
                 client_id = os.getenv("AZURE_CLIENT_ID", "")

--- a/src/azure_haymaker/orchestrator/container_lifecycle.py
+++ b/src/azure_haymaker/orchestrator/container_lifecycle.py
@@ -6,17 +6,16 @@ on Azure using the repository pattern for clean abstraction.
 
 import logging
 
+from azure_haymaker.exceptions import ContainerError
+
 from .repositories.base_repository import RepositoryError
 from .repositories.container_repository import ContainerAppRepository
 
 # Configure logging
 logger = logging.getLogger(__name__)
 
-
-class ContainerAppError(Exception):
-    """Raised when container app operations fail."""
-
-    pass
+# Backward compatibility alias - use ContainerError from central exceptions
+ContainerAppError = ContainerError
 
 
 class ContainerLifecycle:

--- a/src/azure_haymaker/orchestrator/container_manager.py
+++ b/src/azure_haymaker/orchestrator/container_manager.py
@@ -8,16 +8,18 @@ and image verification while maintaining backward compatibility.
 import logging
 from typing import Any
 
+from azure_haymaker.exceptions import ContainerError
 from azure_haymaker.models.config import OrchestratorConfig
 from azure_haymaker.models.scenario import ScenarioMetadata
 from azure_haymaker.models.service_principal import ServicePrincipalDetails
 
-# Import specialized classes
-# Import exceptions and functions for re-export
-from .container_deployer import ContainerAppError, ContainerDeployer
+from .container_deployer import ContainerDeployer
 from .container_lifecycle import ContainerLifecycle
 from .container_monitor import ContainerMonitor
 from .image_verifier import ImageSigningError, ImageVerifier, verify_image_signature
+
+# Backward compatibility alias for exception re-export
+ContainerAppError = ContainerError
 
 # Configure logging
 logger = logging.getLogger(__name__)

--- a/src/azure_haymaker/orchestrator/container_monitor.py
+++ b/src/azure_haymaker/orchestrator/container_monitor.py
@@ -10,14 +10,13 @@ import logging
 from azure.core.exceptions import ResourceNotFoundError
 from azure.identity import DefaultAzureCredential
 
+from azure_haymaker.exceptions import ContainerError
+
 # Configure logging
 logger = logging.getLogger(__name__)
 
-
-class ContainerAppError(Exception):
-    """Raised when container app operations fail."""
-
-    pass
+# Backward compatibility alias - use ContainerError from central exceptions
+ContainerAppError = ContainerError
 
 
 class ContainerMonitor:

--- a/src/azure_haymaker/orchestrator/sp_manager.py
+++ b/src/azure_haymaker/orchestrator/sp_manager.py
@@ -26,6 +26,7 @@ from msgraph.generated.models.service_principal import ServicePrincipal
 from msgraph.graph_service_client import GraphServiceClient
 from pydantic import BaseModel, Field
 
+from azure_haymaker.exceptions import ServicePrincipalError
 from azure_haymaker.utils.credentials import get_credential, get_tenant_credential
 
 logger = logging.getLogger(__name__)
@@ -45,12 +46,6 @@ def sanitize_odata_value(value: str) -> str:
     """
     # Escape single quotes by doubling them (OData standard)
     return value.replace("'", "''")
-
-
-class ServicePrincipalError(Exception):
-    """Raised when service principal operations fail."""
-
-    pass
 
 
 class ServicePrincipalDetails(BaseModel):
@@ -151,8 +146,8 @@ async def create_service_principal(  # pyright: ignore[reportGeneralTypeIssues,r
             extra={
                 "scenario": scenario_name,
                 "target_tenant": config.target_tenant_id[:8] + "...",
-                "mode": "cross-tenant" if config.is_cross_tenant else "single-tenant"
-            }
+                "mode": "cross-tenant" if config.is_cross_tenant else "single-tenant",
+            },
         )
 
         graph_client = GraphServiceClient(credential)


### PR DESCRIPTION
## Summary

- Remove duplicate `ContainerAppError` class definitions from 3 orchestrator modules (container_deployer.py, container_monitor.py, container_lifecycle.py)
- Remove duplicate `ConfigurationError` class definition from config.py
- Remove duplicate `ServicePrincipalError` class definition from sp_manager.py
- Import all exceptions from central `azure_haymaker.exceptions` module
- Maintain backward compatibility via module-level aliases for re-exports

## Test plan

- [x] Ran all unit tests for modified modules (passed)
- [x] Verified imports work correctly from all modules
- [x] Verified backward compatibility aliases preserve existing API
- [ ] CI/CD pipeline passes

## Technical Details

The central `azure_haymaker.exceptions` module already defines rich exception classes with proper attributes and serialization. This change consolidates duplicate class definitions to use the central module.

**Files Modified:**
- `src/azure_haymaker/orchestrator/__init__.py` - Updated public exports
- `src/azure_haymaker/orchestrator/container_deployer.py` - Removed local class, added alias
- `src/azure_haymaker/orchestrator/container_monitor.py` - Removed local class, added alias
- `src/azure_haymaker/orchestrator/container_lifecycle.py` - Removed local class, added alias
- `src/azure_haymaker/orchestrator/container_manager.py` - Updated imports
- `src/azure_haymaker/orchestrator/config.py` - Removed local class
- `src/azure_haymaker/orchestrator/sp_manager.py` - Removed local class

Closes #221

---
Generated with [Claude Code](https://claude.com/claude-code)