### PR TITLE
test: Add comprehensive unit tests for 4 critical modules

### DIFF
--- a/tests/unit/test_email_generator.py
+++ b/tests/unit/test_email_generator.py
@@ -1,0 +1,598 @@
+"""Tests for email_generator module.
+
+Comprehensive unit tests for AI-powered email generation using Anthropic Claude.
+Tests cover:
+- EmailContent dataclass
+- EmailGenerationConfig validation
+- EmailContentGenerator initialization and generation
+- Input validation and security
+- Error handling (rate limits, timeouts, API errors)
+- Response parsing
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from anthropic import AnthropicError, RateLimitError
+from anthropic.types import Message, TextBlock, Usage
+
+from azure_haymaker.knowledge_worker.content.email_generator import (
+    DEPARTMENT_PATTERN,
+    EMAIL_PATTERN,
+    WORKER_ID_PATTERN,
+    EmailContent,
+    EmailContentGenerator,
+    EmailGenerationConfig,
+    sanitize_error_message,
+    validate_input,
+)
+
+if TYPE_CHECKING:
+    pass
+
+
+# =============================================================================
+# UNIT TESTS - EmailContent dataclass
+# =============================================================================
+
+
+class TestEmailContent:
+    """Tests for EmailContent dataclass."""
+
+    def test_email_content_creation(self) -> None:
+        """Test basic EmailContent creation."""
+        content = EmailContent(
+            subject="Test Subject",
+            body="<p>Test body</p>",
+        )
+        assert content.subject == "Test Subject"
+        assert content.body == "<p>Test body</p>"
+        assert content.metadata == {}
+
+    def test_email_content_with_metadata(self) -> None:
+        """Test EmailContent with metadata."""
+        metadata = {
+            "source": "anthropic_claude",
+            "model": "claude-sonnet-4-5-20250929",
+            "tokens_used": 100,
+        }
+        content = EmailContent(
+            subject="Meeting Update",
+            body="<p>The meeting is rescheduled.</p>",
+            metadata=metadata,
+        )
+        assert content.metadata["source"] == "anthropic_claude"
+        assert content.metadata["tokens_used"] == 100
+
+
+# =============================================================================
+# UNIT TESTS - EmailGenerationConfig
+# =============================================================================
+
+
+class TestEmailGenerationConfig:
+    """Tests for EmailGenerationConfig Pydantic model."""
+
+    def test_default_config(self) -> None:
+        """Test default configuration values."""
+        config = EmailGenerationConfig()
+        assert config.enabled is False
+        assert config.api_key is None
+        assert config.model is None
+        assert config.directive is None
+        assert config.max_tokens == 1024
+        assert config.temperature == 0.7
+        assert config.timeout_seconds == 30
+
+    def test_enabled_config(self) -> None:
+        """Test enabled configuration with custom values."""
+        config = EmailGenerationConfig(
+            enabled=True,
+            api_key="sk-ant-test-key",
+            model="claude-sonnet-4-5-20250929",
+            directive="Include a limerick",
+            max_tokens=2048,
+            temperature=0.9,
+            timeout_seconds=60,
+        )
+        assert config.enabled is True
+        assert config.api_key == "sk-ant-test-key"
+        assert config.model == "claude-sonnet-4-5-20250929"
+        assert config.directive == "Include a limerick"
+        assert config.max_tokens == 2048
+        assert config.temperature == 0.9
+        assert config.timeout_seconds == 60
+
+
+# =============================================================================
+# UNIT TESTS - Input Validation
+# =============================================================================
+
+
+class TestInputValidation:
+    """Tests for input validation functions."""
+
+    def test_validate_worker_id_valid(self) -> None:
+        """Test valid worker IDs."""
+        valid_ids = ["kw-eng-1", "worker_123", "KW-ABC-001", "test-worker"]
+        for worker_id in valid_ids:
+            validate_input(worker_id, WORKER_ID_PATTERN, "worker_id")
+
+    def test_validate_worker_id_invalid(self) -> None:
+        """Test invalid worker IDs raise ValueError."""
+        invalid_ids = [
+            "kw eng 1",  # spaces
+            "worker@123",  # special chars
+            "a" * 65,  # too long
+            "",  # empty
+        ]
+        for worker_id in invalid_ids:
+            with pytest.raises(ValueError, match="Invalid worker_id"):
+                validate_input(worker_id, WORKER_ID_PATTERN, "worker_id")
+
+    def test_validate_department_valid(self) -> None:
+        """Test valid department names."""
+        valid_depts = ["engineering", "hr", "SALES", "tech-ops"]
+        for dept in valid_depts:
+            validate_input(dept, DEPARTMENT_PATTERN, "department")
+
+    def test_validate_department_invalid(self) -> None:
+        """Test invalid department names raise ValueError."""
+        invalid_depts = [
+            "tech ops",  # spaces
+            "HR@Corp",  # special chars
+            "d" * 51,  # too long
+        ]
+        for dept in invalid_depts:
+            with pytest.raises(ValueError, match="Invalid department"):
+                validate_input(dept, DEPARTMENT_PATTERN, "department")
+
+    def test_validate_email_valid(self) -> None:
+        """Test valid email addresses."""
+        valid_emails = [
+            "user@example.com",
+            "test.user@corp.onmicrosoft.com",
+            "kw-eng-1@tenant.com",
+        ]
+        for email in valid_emails:
+            validate_input(email, EMAIL_PATTERN, "recipient")
+
+    def test_validate_email_invalid(self) -> None:
+        """Test invalid email addresses raise ValueError."""
+        invalid_emails = [
+            "not-an-email",
+            "user@",
+            "@domain.com",
+            "user@.com",
+        ]
+        for email in invalid_emails:
+            with pytest.raises(ValueError, match="Invalid recipient"):
+                validate_input(email, EMAIL_PATTERN, "recipient")
+
+
+# =============================================================================
+# UNIT TESTS - Error Sanitization
+# =============================================================================
+
+
+class TestErrorSanitization:
+    """Tests for error message sanitization."""
+
+    def test_sanitize_api_keys(self) -> None:
+        """Test API keys are redacted from error messages."""
+        error = Exception("Error with key sk-ant-api123abc")
+        sanitized = sanitize_error_message(error)
+        assert "sk-ant-api123abc" not in sanitized
+        assert "[REDACTED]" in sanitized
+
+    def test_sanitize_tokens(self) -> None:
+        """Test tokens are redacted."""
+        error = Exception("Failed with token: abc123xyz")
+        sanitized = sanitize_error_message(error)
+        assert "abc123xyz" not in sanitized
+        assert "[REDACTED]" in sanitized
+
+    def test_sanitize_file_paths(self) -> None:
+        """Test file paths are redacted."""
+        error = Exception("Error in /home/user/project/secret.py")
+        sanitized = sanitize_error_message(error)
+        assert "/home/user/project/secret.py" not in sanitized
+        assert "[PATH]" in sanitized
+
+
+# =============================================================================
+# UNIT TESTS - EmailContentGenerator Initialization
+# =============================================================================
+
+
+class TestEmailContentGeneratorInit:
+    """Tests for EmailContentGenerator initialization."""
+
+    def test_init_disabled(self) -> None:
+        """Test initialization with disabled config."""
+        config = EmailGenerationConfig(enabled=False)
+        generator = EmailContentGenerator(config)
+        assert generator.client is None
+
+    @patch("azure_haymaker.knowledge_worker.content.email_generator.Anthropic")
+    def test_init_enabled_with_api_key(self, mock_anthropic: MagicMock) -> None:
+        """Test initialization with enabled config and API key."""
+        config = EmailGenerationConfig(
+            enabled=True,
+            api_key="sk-ant-test-key",
+            timeout_seconds=45,
+        )
+        generator = EmailContentGenerator(config)
+        mock_anthropic.assert_called_once_with(
+            api_key="sk-ant-test-key",
+            timeout=45,
+        )
+        assert generator.client is not None
+
+    @patch("azure_haymaker.knowledge_worker.content.email_generator.Anthropic")
+    def test_init_enabled_without_api_key(self, mock_anthropic: MagicMock) -> None:
+        """Test initialization uses env var when no API key provided."""
+        config = EmailGenerationConfig(enabled=True)
+        generator = EmailContentGenerator(config)
+        mock_anthropic.assert_called_once_with(
+            api_key=None,
+            timeout=30,
+        )
+        assert generator.client is not None
+
+    @patch("azure_haymaker.knowledge_worker.content.email_generator.Anthropic")
+    def test_init_client_error(self, mock_anthropic: MagicMock) -> None:
+        """Test initialization handles Anthropic client errors."""
+        mock_anthropic.side_effect = Exception("Invalid API key sk-ant-secret123")
+        config = EmailGenerationConfig(enabled=True, api_key="bad-key")
+
+        with pytest.raises(ValueError, match="Failed to initialize Anthropic client") as exc_info:
+            EmailContentGenerator(config)
+
+        # Verify error is sanitized
+        assert "sk-ant-secret123" not in str(exc_info.value)
+        assert "[REDACTED]" in str(exc_info.value)
+
+
+# =============================================================================
+# UNIT TESTS - Email Generation
+# =============================================================================
+
+
+class TestEmailGeneration:
+    """Tests for email generation functionality."""
+
+    @pytest.fixture
+    def mock_anthropic_response(self) -> Message:
+        """Create a mock Anthropic API response."""
+        text_block = MagicMock(spec=TextBlock)
+        text_block.text = "Subject: Test Subject Line\nBody: This is the email body content."
+        # Make isinstance check work
+        text_block.__class__ = TextBlock
+
+        usage = MagicMock(spec=Usage)
+        usage.output_tokens = 50
+
+        response = MagicMock(spec=Message)
+        response.content = [text_block]
+        response.usage = usage
+        return response
+
+    @pytest.fixture
+    def generator_with_mock_client(self) -> tuple[EmailContentGenerator, MagicMock]:
+        """Create generator with mocked Anthropic client."""
+        with patch(
+            "azure_haymaker.knowledge_worker.content.email_generator.Anthropic"
+        ) as mock_anthropic:
+            mock_client = MagicMock()
+            mock_anthropic.return_value = mock_client
+
+            config = EmailGenerationConfig(
+                enabled=True,
+                api_key="sk-ant-test-key",
+            )
+            generator = EmailContentGenerator(config)
+            return generator, mock_client
+
+    @pytest.mark.asyncio
+    async def test_generate_email_disabled(self) -> None:
+        """Test generate_email raises when disabled."""
+        config = EmailGenerationConfig(enabled=False)
+        generator = EmailContentGenerator(config)
+
+        with pytest.raises(RuntimeError, match="AI email generation is not enabled"):
+            await generator.generate_email(
+                worker_id="kw-eng-1",
+                department="engineering",
+                recipient="user@test.com",
+                activity_count=1,
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_email_success(
+        self,
+        generator_with_mock_client: tuple[EmailContentGenerator, MagicMock],
+        mock_anthropic_response: Message,
+    ) -> None:
+        """Test successful email generation."""
+        generator, mock_client = generator_with_mock_client
+        mock_client.messages.create.return_value = mock_anthropic_response
+
+        content = await generator.generate_email(
+            worker_id="kw-eng-1",
+            department="engineering",
+            recipient="user@test.com",
+            activity_count=42,
+            run_id="run-123",
+        )
+
+        assert content.subject == "Test Subject Line"
+        assert "email body content" in content.body
+        assert content.metadata["source"] == "anthropic_claude"
+        assert content.metadata["worker_id"] == "kw-eng-1"
+        assert content.metadata["department"] == "engineering"
+        assert content.metadata["activity_count"] == 42
+        assert content.metadata["run_id"] == "run-123"
+        assert content.metadata["tokens_used"] == 50
+
+    @pytest.mark.asyncio
+    async def test_generate_email_default_model(
+        self,
+        generator_with_mock_client: tuple[EmailContentGenerator, MagicMock],
+        mock_anthropic_response: Message,
+    ) -> None:
+        """Test default model is used when not specified."""
+        generator, mock_client = generator_with_mock_client
+        mock_client.messages.create.return_value = mock_anthropic_response
+
+        await generator.generate_email(
+            worker_id="kw-eng-1",
+            department="engineering",
+            recipient="user@test.com",
+            activity_count=1,
+        )
+
+        call_args = mock_client.messages.create.call_args
+        assert call_args.kwargs["model"] == "claude-sonnet-4-5-20250929"
+
+    @pytest.mark.asyncio
+    async def test_generate_email_invalid_worker_id(
+        self,
+        generator_with_mock_client: tuple[EmailContentGenerator, MagicMock],
+    ) -> None:
+        """Test validation fails for invalid worker_id."""
+        generator, _ = generator_with_mock_client
+
+        with pytest.raises(ValueError, match="Invalid worker_id"):
+            await generator.generate_email(
+                worker_id="invalid worker",  # spaces not allowed
+                department="engineering",
+                recipient="user@test.com",
+                activity_count=1,
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_email_invalid_activity_count(
+        self,
+        generator_with_mock_client: tuple[EmailContentGenerator, MagicMock],
+    ) -> None:
+        """Test validation fails for out-of-range activity_count."""
+        generator, _ = generator_with_mock_client
+
+        with pytest.raises(ValueError, match="activity_count must be between"):
+            await generator.generate_email(
+                worker_id="kw-eng-1",
+                department="engineering",
+                recipient="user@test.com",
+                activity_count=-1,
+            )
+
+        with pytest.raises(ValueError, match="activity_count must be between"):
+            await generator.generate_email(
+                worker_id="kw-eng-1",
+                department="engineering",
+                recipient="user@test.com",
+                activity_count=1_000_001,
+            )
+
+
+# =============================================================================
+# UNIT TESTS - Error Handling
+# =============================================================================
+
+
+class TestErrorHandling:
+    """Tests for API error handling."""
+
+    @pytest.fixture
+    def generator_with_mock_client(self) -> tuple[EmailContentGenerator, MagicMock]:
+        """Create generator with mocked Anthropic client."""
+        with patch(
+            "azure_haymaker.knowledge_worker.content.email_generator.Anthropic"
+        ) as mock_anthropic:
+            mock_client = MagicMock()
+            mock_anthropic.return_value = mock_client
+
+            config = EmailGenerationConfig(
+                enabled=True,
+                api_key="sk-ant-test-key",
+            )
+            generator = EmailContentGenerator(config)
+            return generator, mock_client
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_error(
+        self,
+        generator_with_mock_client: tuple[EmailContentGenerator, MagicMock],
+    ) -> None:
+        """Test rate limit errors are handled properly."""
+        generator, mock_client = generator_with_mock_client
+
+        # Create RateLimitError with required args
+        rate_limit_error = RateLimitError(
+            message="Rate limit exceeded",
+            response=MagicMock(status_code=429),
+            body={"error": {"message": "Rate limit exceeded"}},
+        )
+        mock_client.messages.create.side_effect = rate_limit_error
+
+        with pytest.raises(RuntimeError, match="rate limits"):
+            await generator.generate_email(
+                worker_id="kw-eng-1",
+                department="engineering",
+                recipient="user@test.com",
+                activity_count=1,
+            )
+
+    @pytest.mark.asyncio
+    async def test_anthropic_api_error(
+        self,
+        generator_with_mock_client: tuple[EmailContentGenerator, MagicMock],
+    ) -> None:
+        """Test Anthropic API errors are handled and sanitized."""
+        generator, mock_client = generator_with_mock_client
+
+        # Create AnthropicError with API key in message
+        api_error = AnthropicError("Error with key sk-ant-secretkey123")
+        mock_client.messages.create.side_effect = api_error
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await generator.generate_email(
+                worker_id="kw-eng-1",
+                department="engineering",
+                recipient="user@test.com",
+                activity_count=1,
+            )
+
+        # Verify sensitive info is redacted
+        assert "sk-ant-secretkey123" not in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error(
+        self,
+        generator_with_mock_client: tuple[EmailContentGenerator, MagicMock],
+    ) -> None:
+        """Test unexpected errors are handled and sanitized."""
+        generator, mock_client = generator_with_mock_client
+        mock_client.messages.create.side_effect = Exception(
+            "Unexpected error with token: secret123"
+        )
+
+        with pytest.raises(RuntimeError, match="Failed to generate email content"):
+            await generator.generate_email(
+                worker_id="kw-eng-1",
+                department="engineering",
+                recipient="user@test.com",
+                activity_count=1,
+            )
+
+
+# =============================================================================
+# UNIT TESTS - Response Parsing
+# =============================================================================
+
+
+class TestResponseParsing:
+    """Tests for email response parsing."""
+
+    @pytest.fixture
+    def generator(self) -> EmailContentGenerator:
+        """Create generator for testing parsing."""
+        with patch("azure_haymaker.knowledge_worker.content.email_generator.Anthropic"):
+            config = EmailGenerationConfig(enabled=True, api_key="test")
+            return EmailContentGenerator(config)
+
+    def test_parse_standard_format(self, generator: EmailContentGenerator) -> None:
+        """Test parsing standard Subject:/Body: format."""
+        content = "Subject: Project Update\nBody: The project is on track for delivery."
+        subject, body = generator._parse_email_response(content)
+
+        assert subject == "Project Update"
+        assert "on track for delivery" in body
+
+    def test_parse_without_body_prefix(self, generator: EmailContentGenerator) -> None:
+        """Test parsing without Body: prefix."""
+        content = "Subject: Meeting Notes\n\nAttached are the meeting notes from today."
+        subject, body = generator._parse_email_response(content)
+
+        assert subject == "Meeting Notes"
+        assert "meeting notes" in body
+
+    def test_parse_multiline_body(self, generator: EmailContentGenerator) -> None:
+        """Test parsing multiline body content."""
+        content = "Subject: Weekly Report\n\nFirst paragraph.\n\nSecond paragraph."
+        subject, body = generator._parse_email_response(content)
+
+        assert subject == "Weekly Report"
+        assert "<p>" in body  # Should be HTML formatted
+
+    def test_parse_empty_content(self, generator: EmailContentGenerator) -> None:
+        """Test parsing empty content returns defaults."""
+        content = ""
+        subject, body = generator._parse_email_response(content)
+
+        assert subject == "Knowledge Worker Activity"
+        assert "Automated activity" in body
+
+    def test_parse_html_escaping(self, generator: EmailContentGenerator) -> None:
+        """Test HTML content is escaped for XSS prevention."""
+        content = "Subject: Test\n<script>alert('xss')</script>"
+        subject, body = generator._parse_email_response(content)
+
+        # Script tag should be escaped
+        assert "<script>" not in body
+        assert "&lt;script&gt;" in body
+
+
+# =============================================================================
+# INTEGRATION TESTS - Full Flow
+# =============================================================================
+
+
+class TestEmailGenerationIntegration:
+    """Integration tests for email generation flow."""
+
+    @pytest.mark.asyncio
+    async def test_full_generation_flow(self) -> None:
+        """Test complete generation flow with mocked API."""
+        with patch(
+            "azure_haymaker.knowledge_worker.content.email_generator.Anthropic"
+        ) as mock_anthropic:
+            # Setup mock response using actual TextBlock instance
+            text_block = TextBlock(
+                type="text",
+                text="Subject: Sprint Planning Update\nBody: The sprint planning meeting has been rescheduled to 3 PM.",
+            )
+
+            usage = MagicMock(spec=Usage)
+            usage.output_tokens = 75
+
+            response = MagicMock(spec=Message)
+            response.content = [text_block]
+            response.usage = usage
+
+            mock_client = MagicMock()
+            mock_client.messages.create.return_value = response
+            mock_anthropic.return_value = mock_client
+
+            # Create generator and generate email
+            config = EmailGenerationConfig(
+                enabled=True,
+                api_key="sk-ant-test",
+                directive="Keep it brief",
+            )
+            generator = EmailContentGenerator(config)
+
+            content = await generator.generate_email(
+                worker_id="kw-eng-1",
+                department="engineering",
+                recipient="user@tenant.com",
+                activity_count=10,
+            )
+
+            assert content.subject == "Sprint Planning Update"
+            assert "rescheduled" in content.body
+            assert content.metadata["tokens_used"] == 75

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -1,0 +1,860 @@
+"""Tests for github_client module.
+
+Comprehensive unit tests for GitHub API client operations including:
+- Client initialization
+- Repository operations
+- Commit and tree management
+- Pull request creation and management
+- Review operations
+- Workflow dispatch
+- Rate limit handling
+- Error handling
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from azure_haymaker.workflow_bricks.clients.github_client import GitHubClient
+
+if TYPE_CHECKING:
+    pass
+
+
+# =============================================================================
+# UNIT TESTS - Client Initialization
+# =============================================================================
+
+
+class TestGitHubClientInit:
+    """Tests for GitHubClient initialization."""
+
+    def test_init_defaults(self) -> None:
+        """Test client initialization with default values."""
+        client = GitHubClient(token="ghp_testtoken")
+
+        assert client.token == "ghp_testtoken"
+        assert client.base_url == "https://api.github.com"
+        assert client.timeout == 30.0
+        assert client._rate_limit_remaining is None
+        assert client._rate_limit_reset is None
+
+    def test_init_custom_values(self) -> None:
+        """Test client initialization with custom values."""
+        client = GitHubClient(
+            token="ghp_testtoken",
+            base_url="https://github.example.com/api/v3/",
+            timeout=60.0,
+        )
+
+        assert client.token == "ghp_testtoken"
+        assert client.base_url == "https://github.example.com/api/v3"  # trailing slash stripped
+        assert client.timeout == 60.0
+
+    def test_get_headers(self) -> None:
+        """Test authentication headers generation."""
+        client = GitHubClient(token="ghp_testtoken")
+        headers = client._get_headers()
+
+        assert headers["Authorization"] == "Bearer ghp_testtoken"
+        assert headers["Accept"] == "application/vnd.github+json"
+        assert headers["X-GitHub-Api-Version"] == "2022-11-28"
+
+    def test_get_repo_url(self) -> None:
+        """Test repository URL generation."""
+        client = GitHubClient(token="ghp_test")
+        url = client.get_repo_url("octocat", "hello-world")
+
+        assert url == "https://api.github.com/repos/octocat/hello-world"
+
+
+# =============================================================================
+# UNIT TESTS - Rate Limit Handling
+# =============================================================================
+
+
+class TestRateLimitHandling:
+    """Tests for rate limit handling."""
+
+    @pytest.mark.asyncio
+    async def test_handle_rate_limit_normal(self) -> None:
+        """Test rate limit handling with remaining requests."""
+        client = GitHubClient(token="ghp_test")
+        response = MagicMock()
+        response.headers = {
+            "X-RateLimit-Remaining": "4999",
+            "X-RateLimit-Reset": "1234567890",
+        }
+
+        await client.handle_rate_limit(response)
+
+        assert client._rate_limit_remaining == 4999
+        assert client._rate_limit_reset == 1234567890
+
+    @pytest.mark.asyncio
+    async def test_handle_rate_limit_exhausted(self) -> None:
+        """Test rate limit handling when limit is exhausted."""
+        client = GitHubClient(token="ghp_test")
+
+        # Set reset time to be in the past to avoid actual sleep
+        import time
+
+        past_reset = int(time.time()) - 10
+
+        response = MagicMock()
+        response.headers = {
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": str(past_reset),
+        }
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            await client.handle_rate_limit(response)
+            # Sleep should be called with 1 second (max(0, past-now) + 1)
+            mock_sleep.assert_called_once()
+
+
+# =============================================================================
+# UNIT TESTS - HTTP Request
+# =============================================================================
+
+
+class TestHttpRequest:
+    """Tests for internal HTTP request handling."""
+
+    @pytest.fixture
+    def mock_httpx_client(self) -> MagicMock:
+        """Create mock httpx client."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {
+            "X-RateLimit-Remaining": "4999",
+            "X-RateLimit-Reset": "1234567890",
+        }
+        mock_response.json.return_value = {"sha": "abc123"}
+        mock_response.raise_for_status = MagicMock()
+        return mock_response
+
+    @pytest.mark.asyncio
+    async def test_request_success(self, mock_httpx_client: MagicMock) -> None:
+        """Test successful HTTP request."""
+        client = GitHubClient(token="ghp_test")
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.request.return_value = mock_httpx_client
+            mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+            result = await client._request("GET", "/repos/test/repo")
+
+            assert result == {"sha": "abc123"}
+            mock_client_instance.request.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_request_no_content(self) -> None:
+        """Test request returns empty dict for 204 response."""
+        client = GitHubClient(token="ghp_test")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_response.headers = {
+            "X-RateLimit-Remaining": "4999",
+            "X-RateLimit-Reset": "1234567890",
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.request.return_value = mock_response
+            mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+            result = await client._request("DELETE", "/repos/test/repo/ref")
+
+            assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_request_http_error(self) -> None:
+        """Test HTTP errors are propagated."""
+        client = GitHubClient(token="ghp_test")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.headers = {
+            "X-RateLimit-Remaining": "4999",
+            "X-RateLimit-Reset": "1234567890",
+        }
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            message="Not Found",
+            request=MagicMock(),
+            response=mock_response,
+        )
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.request.return_value = mock_response
+            mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+            with pytest.raises(httpx.HTTPStatusError):
+                await client._request("GET", "/repos/nonexistent/repo")
+
+
+# =============================================================================
+# UNIT TESTS - Commit Operations
+# =============================================================================
+
+
+class TestCommitOperations:
+    """Tests for commit-related operations."""
+
+    @pytest.fixture
+    def client(self) -> GitHubClient:
+        """Create client for testing."""
+        return GitHubClient(token="ghp_test")
+
+    @pytest.mark.asyncio
+    async def test_create_commit_basic(self, client: GitHubClient) -> None:
+        """Test basic commit creation."""
+        expected_response = {
+            "sha": "commit123",
+            "message": "Test commit",
+        }
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = expected_response
+
+            result = await client.create_commit(
+                owner="octocat",
+                repo="hello-world",
+                message="Test commit",
+                tree_sha="tree123",
+                parent_sha="parent123",
+            )
+
+            assert result["sha"] == "commit123"
+            mock_request.assert_called_once_with(
+                "POST",
+                "/repos/octocat/hello-world/git/commits",
+                json={
+                    "message": "Test commit",
+                    "tree": "tree123",
+                    "parents": ["parent123"],
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_commit_with_author(self, client: GitHubClient) -> None:
+        """Test commit creation with author info."""
+        expected_response = {"sha": "commit123"}
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = expected_response
+
+            await client.create_commit(
+                owner="octocat",
+                repo="hello-world",
+                message="Test commit",
+                tree_sha="tree123",
+                parent_sha="parent123",
+                author_name="Test User",
+                author_email="test@example.com",
+            )
+
+            call_args = mock_request.call_args
+            assert call_args[1]["json"]["author"]["name"] == "Test User"
+            assert call_args[1]["json"]["author"]["email"] == "test@example.com"
+
+
+# =============================================================================
+# UNIT TESTS - Reference Operations
+# =============================================================================
+
+
+class TestReferenceOperations:
+    """Tests for git reference operations."""
+
+    @pytest.fixture
+    def client(self) -> GitHubClient:
+        """Create client for testing."""
+        return GitHubClient(token="ghp_test")
+
+    @pytest.mark.asyncio
+    async def test_get_ref(self, client: GitHubClient) -> None:
+        """Test getting a git reference."""
+        expected_response = {
+            "ref": "refs/heads/main",
+            "object": {"sha": "abc123"},
+        }
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = expected_response
+
+            result = await client.get_ref("octocat", "hello-world", "heads/main")
+
+            assert result["object"]["sha"] == "abc123"
+            mock_request.assert_called_once_with(
+                "GET",
+                "/repos/octocat/hello-world/git/ref/heads/main",
+            )
+
+    @pytest.mark.asyncio
+    async def test_update_ref(self, client: GitHubClient) -> None:
+        """Test updating a git reference."""
+        expected_response = {"ref": "refs/heads/main", "object": {"sha": "new123"}}
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = expected_response
+
+            result = await client.update_ref(
+                owner="octocat",
+                repo="hello-world",
+                ref="heads/main",
+                sha="new123",
+                force=True,
+            )
+
+            assert result["object"]["sha"] == "new123"
+            mock_request.assert_called_once_with(
+                "PATCH",
+                "/repos/octocat/hello-world/git/refs/heads/main",
+                json={"sha": "new123", "force": True},
+            )
+
+
+# =============================================================================
+# UNIT TESTS - Tree and Blob Operations
+# =============================================================================
+
+
+class TestTreeBlobOperations:
+    """Tests for tree and blob operations."""
+
+    @pytest.fixture
+    def client(self) -> GitHubClient:
+        """Create client for testing."""
+        return GitHubClient(token="ghp_test")
+
+    @pytest.mark.asyncio
+    async def test_create_tree(self, client: GitHubClient) -> None:
+        """Test creating a git tree."""
+        tree_entries = [
+            {
+                "path": "README.md",
+                "mode": "100644",
+                "type": "blob",
+                "sha": "blob123",
+            }
+        ]
+        expected_response = {"sha": "tree123"}
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = expected_response
+
+            result = await client.create_tree(
+                owner="octocat",
+                repo="hello-world",
+                base_tree="base123",
+                tree=tree_entries,
+            )
+
+            assert result["sha"] == "tree123"
+
+    @pytest.mark.asyncio
+    async def test_get_blob(self, client: GitHubClient) -> None:
+        """Test getting a blob."""
+        expected_response = {
+            "sha": "blob123",
+            "content": "SGVsbG8gV29ybGQh",  # base64 encoded
+            "encoding": "base64",
+        }
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = expected_response
+
+            result = await client.get_blob(
+                owner="octocat",
+                repo="hello-world",
+                file_sha="blob123",
+            )
+
+            assert result["sha"] == "blob123"
+            assert result["content"] == "SGVsbG8gV29ybGQh"
+
+    @pytest.mark.asyncio
+    async def test_create_blob(self, client: GitHubClient) -> None:
+        """Test creating a blob."""
+        expected_response = {"sha": "newblob123"}
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = expected_response
+
+            result = await client.create_blob(
+                owner="octocat",
+                repo="hello-world",
+                content="Hello World!",
+                encoding="utf-8",
+            )
+
+            assert result["sha"] == "newblob123"
+            mock_request.assert_called_once_with(
+                "POST",
+                "/repos/octocat/hello-world/git/blobs",
+                json={"content": "Hello World!", "encoding": "utf-8"},
+            )
+
+
+# =============================================================================
+# UNIT TESTS - Pull Request Operations
+# =============================================================================
+
+
+class TestPullRequestOperations:
+    """Tests for pull request operations."""
+
+    @pytest.fixture
+    def client(self) -> GitHubClient:
+        """Create client for testing."""
+        return GitHubClient(token="ghp_test")
+
+    @pytest.mark.asyncio
+    async def test_create_pull_request(self, client: GitHubClient) -> None:
+        """Test creating a pull request."""
+        expected_response = {
+            "number": 42,
+            "html_url": "https://github.com/octocat/hello-world/pull/42",
+            "state": "open",
+        }
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = expected_response
+
+            result = await client.create_pull_request(
+                owner="octocat",
+                repo="hello-world",
+                title="Add feature",
+                body="This PR adds a new feature.",
+                head="feature-branch",
+                base="main",
+                draft=False,
+            )
+
+            assert result["number"] == 42
+            mock_request.assert_called_once_with(
+                "POST",
+                "/repos/octocat/hello-world/pulls",
+                json={
+                    "title": "Add feature",
+                    "body": "This PR adds a new feature.",
+                    "head": "feature-branch",
+                    "base": "main",
+                    "draft": False,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_pull_request_draft(self, client: GitHubClient) -> None:
+        """Test creating a draft pull request."""
+        expected_response = {"number": 43, "draft": True}
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = expected_response
+
+            result = await client.create_pull_request(
+                owner="octocat",
+                repo="hello-world",
+                title="WIP: Feature",
+                body="Work in progress",
+                head="wip-branch",
+                base="main",
+                draft=True,
+            )
+
+            assert result["draft"] is True
+
+    @pytest.mark.asyncio
+    async def test_get_pull_request(self, client: GitHubClient) -> None:
+        """Test getting a pull request."""
+        expected_response = {
+            "number": 42,
+            "title": "Add feature",
+            "state": "open",
+        }
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = expected_response
+
+            result = await client.get_pull_request(
+                owner="octocat",
+                repo="hello-world",
+                pull_number=42,
+            )
+
+            assert result["number"] == 42
+            mock_request.assert_called_once_with(
+                "GET",
+                "/repos/octocat/hello-world/pulls/42",
+            )
+
+    @pytest.mark.asyncio
+    async def test_merge_pull_request(self, client: GitHubClient) -> None:
+        """Test merging a pull request."""
+        expected_response = {
+            "sha": "merge123",
+            "merged": True,
+        }
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = expected_response
+
+            result = await client.merge_pull_request(
+                owner="octocat",
+                repo="hello-world",
+                pull_number=42,
+                merge_method="squash",
+                commit_title="feat: Add feature (#42)",
+                commit_message="Detailed description",
+            )
+
+            assert result["merged"] is True
+            mock_request.assert_called_once_with(
+                "PUT",
+                "/repos/octocat/hello-world/pulls/42/merge",
+                json={
+                    "merge_method": "squash",
+                    "commit_title": "feat: Add feature (#42)",
+                    "commit_message": "Detailed description",
+                },
+            )
+
+
+# =============================================================================
+# UNIT TESTS - Label Operations
+# =============================================================================
+
+
+class TestLabelOperations:
+    """Tests for label operations."""
+
+    @pytest.fixture
+    def client(self) -> GitHubClient:
+        """Create client for testing."""
+        return GitHubClient(token="ghp_test")
+
+    @pytest.mark.asyncio
+    async def test_add_labels(self, client: GitHubClient) -> None:
+        """Test adding labels to an issue/PR."""
+        expected_response = [
+            {"name": "bug", "color": "d73a4a"},
+            {"name": "enhancement", "color": "a2eeef"},
+        ]
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = expected_response
+
+            result = await client.add_labels(
+                owner="octocat",
+                repo="hello-world",
+                issue_number=42,
+                labels=["bug", "enhancement"],
+            )
+
+            assert len(result) == 2
+            mock_request.assert_called_once_with(
+                "POST",
+                "/repos/octocat/hello-world/issues/42/labels",
+                json={"labels": ["bug", "enhancement"]},
+            )
+
+
+# =============================================================================
+# UNIT TESTS - Review Operations
+# =============================================================================
+
+
+class TestReviewOperations:
+    """Tests for pull request review operations."""
+
+    @pytest.fixture
+    def client(self) -> GitHubClient:
+        """Create client for testing."""
+        return GitHubClient(token="ghp_test")
+
+    @pytest.mark.asyncio
+    async def test_request_reviewers(self, client: GitHubClient) -> None:
+        """Test requesting reviewers."""
+        expected_response = {
+            "requested_reviewers": [{"login": "reviewer1"}, {"login": "reviewer2"}]
+        }
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = expected_response
+
+            result = await client.request_reviewers(
+                owner="octocat",
+                repo="hello-world",
+                pull_number=42,
+                reviewers=["reviewer1", "reviewer2"],
+            )
+
+            assert len(result["requested_reviewers"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_create_review_approve(self, client: GitHubClient) -> None:
+        """Test creating an approval review."""
+        expected_response = {"id": 12345, "state": "APPROVED"}
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = expected_response
+
+            result = await client.create_review(
+                owner="octocat",
+                repo="hello-world",
+                pull_number=42,
+                body="LGTM!",
+                event="APPROVE",
+            )
+
+            assert result["state"] == "APPROVED"
+
+    @pytest.mark.asyncio
+    async def test_create_review_with_comments(self, client: GitHubClient) -> None:
+        """Test creating a review with line comments."""
+        comments = [
+            {
+                "path": "src/main.py",
+                "position": 10,
+                "body": "Consider using a constant here.",
+            }
+        ]
+        expected_response = {"id": 12346, "state": "COMMENTED"}
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = expected_response
+
+            await client.create_review(
+                owner="octocat",
+                repo="hello-world",
+                pull_number=42,
+                body="Some suggestions",
+                event="COMMENT",
+                comments=comments,
+            )
+
+            call_args = mock_request.call_args[1]["json"]
+            assert call_args["comments"] == comments
+
+
+# =============================================================================
+# UNIT TESTS - Workflow Operations
+# =============================================================================
+
+
+class TestWorkflowOperations:
+    """Tests for GitHub Actions workflow operations."""
+
+    @pytest.fixture
+    def client(self) -> GitHubClient:
+        """Create client for testing."""
+        return GitHubClient(token="ghp_test")
+
+    @pytest.mark.asyncio
+    async def test_trigger_workflow(self, client: GitHubClient) -> None:
+        """Test triggering a workflow dispatch."""
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = {}  # 204 response
+
+            result = await client.trigger_workflow(
+                owner="octocat",
+                repo="hello-world",
+                workflow_id="ci.yml",
+                ref="main",
+                inputs={"environment": "production"},
+            )
+
+            assert result["status"] == "queued"
+            assert result["workflow_id"] == "ci.yml"
+            mock_request.assert_called_once_with(
+                "POST",
+                "/repos/octocat/hello-world/actions/workflows/ci.yml/dispatches",
+                json={"ref": "main", "inputs": {"environment": "production"}},
+            )
+
+    @pytest.mark.asyncio
+    async def test_trigger_workflow_no_inputs(self, client: GitHubClient) -> None:
+        """Test triggering workflow without inputs."""
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = {}
+
+            await client.trigger_workflow(
+                owner="octocat",
+                repo="hello-world",
+                workflow_id="ci.yml",
+                ref="main",
+            )
+
+            call_args = mock_request.call_args[1]["json"]
+            assert "inputs" not in call_args
+
+    @pytest.mark.asyncio
+    async def test_get_workflow_runs(self, client: GitHubClient) -> None:
+        """Test getting workflow runs."""
+        expected_response = {
+            "total_count": 2,
+            "workflow_runs": [
+                {"id": 1, "status": "completed"},
+                {"id": 2, "status": "in_progress"},
+            ],
+        }
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = expected_response
+
+            result = await client.get_workflow_runs(
+                owner="octocat",
+                repo="hello-world",
+                workflow_id="ci.yml",
+                branch="main",
+                per_page=10,
+            )
+
+            assert len(result["workflow_runs"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_workflow_runs_no_filter(self, client: GitHubClient) -> None:
+        """Test getting all workflow runs without filters."""
+        expected_response = {"workflow_runs": []}
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = expected_response
+
+            await client.get_workflow_runs(
+                owner="octocat",
+                repo="hello-world",
+            )
+
+            # Should use /actions/runs endpoint
+            call_args = mock_request.call_args[0]
+            assert "/actions/runs" in call_args[1]
+
+
+# =============================================================================
+# UNIT TESTS - Branch Operations
+# =============================================================================
+
+
+class TestBranchOperations:
+    """Tests for branch operations."""
+
+    @pytest.fixture
+    def client(self) -> GitHubClient:
+        """Create client for testing."""
+        return GitHubClient(token="ghp_test")
+
+    @pytest.mark.asyncio
+    async def test_delete_branch_success(self, client: GitHubClient) -> None:
+        """Test successful branch deletion."""
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = {}
+
+            result = await client.delete_branch(
+                owner="octocat",
+                repo="hello-world",
+                branch="feature-branch",
+            )
+
+            assert result is True
+            mock_request.assert_called_once_with(
+                "DELETE",
+                "/repos/octocat/hello-world/git/refs/heads/feature-branch",
+            )
+
+    @pytest.mark.asyncio
+    async def test_delete_branch_protected(self, client: GitHubClient) -> None:
+        """Test deleting a protected branch returns False."""
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_response = MagicMock()
+            mock_response.status_code = 422
+            mock_request.side_effect = httpx.HTTPStatusError(
+                message="Protected branch",
+                request=MagicMock(),
+                response=mock_response,
+            )
+
+            result = await client.delete_branch(
+                owner="octocat",
+                repo="hello-world",
+                branch="main",
+            )
+
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_delete_branch_other_error(self, client: GitHubClient) -> None:
+        """Test other errors are propagated."""
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_response = MagicMock()
+            mock_response.status_code = 500
+            mock_request.side_effect = httpx.HTTPStatusError(
+                message="Server error",
+                request=MagicMock(),
+                response=mock_response,
+            )
+
+            with pytest.raises(httpx.HTTPStatusError):
+                await client.delete_branch(
+                    owner="octocat",
+                    repo="hello-world",
+                    branch="feature-branch",
+                )
+
+
+# =============================================================================
+# INTEGRATION TESTS - Full Workflows
+# =============================================================================
+
+
+class TestGitHubClientIntegration:
+    """Integration tests for GitHub client workflows."""
+
+    @pytest.mark.asyncio
+    async def test_create_commit_and_update_ref_flow(self) -> None:
+        """Test complete flow of creating a commit and updating a ref."""
+        client = GitHubClient(token="ghp_test")
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            # Setup mock responses for each call
+            mock_request.side_effect = [
+                {"sha": "tree123"},  # create_tree
+                {"sha": "commit123"},  # create_commit
+                {"ref": "refs/heads/main", "object": {"sha": "commit123"}},  # update_ref
+            ]
+
+            # Create tree
+            tree_result = await client.create_tree(
+                owner="octocat",
+                repo="hello-world",
+                base_tree="base123",
+                tree=[{"path": "README.md", "mode": "100644", "type": "blob", "sha": "blob123"}],
+            )
+
+            # Create commit
+            commit_result = await client.create_commit(
+                owner="octocat",
+                repo="hello-world",
+                message="Update README",
+                tree_sha=tree_result["sha"],
+                parent_sha="parent123",
+            )
+
+            # Update ref
+            ref_result = await client.update_ref(
+                owner="octocat",
+                repo="hello-world",
+                ref="heads/main",
+                sha=commit_result["sha"],
+            )
+
+            assert ref_result["object"]["sha"] == "commit123"
+            assert mock_request.call_count == 3

--- a/tests/unit/test_m365_client.py
+++ b/tests/unit/test_m365_client.py
@@ -1,0 +1,475 @@
+"""Tests for m365_client module.
+
+Comprehensive unit tests for M365 Graph API client factory including:
+- M365ClientConfig creation and environment loading
+- M365Client wrapper functionality
+- M365ClientFactory client creation
+- Authentication handling
+- Error responses for missing credentials
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from azure_haymaker.knowledge_worker.m365_client import (
+    M365Client,
+    M365ClientConfig,
+    M365ClientFactory,
+)
+
+if TYPE_CHECKING:
+    pass
+
+
+# =============================================================================
+# UNIT TESTS - M365ClientConfig
+# =============================================================================
+
+
+class TestM365ClientConfig:
+    """Tests for M365ClientConfig dataclass."""
+
+    def test_config_creation(self) -> None:
+        """Test basic config creation."""
+        config = M365ClientConfig(
+            tenant_id="test-tenant-id",
+            client_id="test-client-id",
+            client_secret="test-secret",
+        )
+
+        assert config.tenant_id == "test-tenant-id"
+        assert config.client_id == "test-client-id"
+        assert config.client_secret == "test-secret"
+
+    def test_config_secret_hidden_from_repr(self) -> None:
+        """Test that client_secret is hidden in repr for security."""
+        config = M365ClientConfig(
+            tenant_id="test-tenant-id",
+            client_id="test-client-id",
+            client_secret="super-secret-value",
+        )
+
+        repr_str = repr(config)
+
+        # Secret should not appear in repr
+        assert "super-secret-value" not in repr_str
+        # Other fields should appear
+        assert "test-tenant-id" in repr_str
+        assert "test-client-id" in repr_str
+
+
+# =============================================================================
+# UNIT TESTS - M365ClientConfig.from_env()
+# =============================================================================
+
+
+class TestM365ClientConfigFromEnv:
+    """Tests for loading config from environment variables."""
+
+    def test_from_env_success(self) -> None:
+        """Test successful config loading from environment."""
+        env_vars = {
+            "KW_TENANT_ID": "env-tenant-id",
+            "KW_APP_ID": "env-app-id",
+            "KW_CLIENT_SECRET": "env-secret",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=False):
+            config = M365ClientConfig.from_env()
+
+            assert config.tenant_id == "env-tenant-id"
+            assert config.client_id == "env-app-id"
+            assert config.client_secret == "env-secret"
+
+    def test_from_env_missing_tenant_id(self) -> None:
+        """Test error when KW_TENANT_ID is missing."""
+        env_vars = {
+            "KW_APP_ID": "env-app-id",
+            "KW_CLIENT_SECRET": "env-secret",
+        }
+
+        with (
+            patch.dict(os.environ, env_vars, clear=True),
+            pytest.raises(ValueError, match="KW_TENANT_ID"),
+        ):
+            M365ClientConfig.from_env()
+
+    def test_from_env_missing_app_id(self) -> None:
+        """Test error when KW_APP_ID is missing."""
+        env_vars = {
+            "KW_TENANT_ID": "env-tenant-id",
+            "KW_CLIENT_SECRET": "env-secret",
+        }
+
+        with (
+            patch.dict(os.environ, env_vars, clear=True),
+            pytest.raises(ValueError, match="KW_APP_ID"),
+        ):
+            M365ClientConfig.from_env()
+
+    def test_from_env_missing_client_secret(self) -> None:
+        """Test error when KW_CLIENT_SECRET is missing."""
+        env_vars = {
+            "KW_TENANT_ID": "env-tenant-id",
+            "KW_APP_ID": "env-app-id",
+        }
+
+        with (
+            patch.dict(os.environ, env_vars, clear=True),
+            pytest.raises(ValueError, match="KW_CLIENT_SECRET"),
+        ):
+            M365ClientConfig.from_env()
+
+    def test_from_env_multiple_missing(self) -> None:
+        """Test error lists all missing variables."""
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(ValueError, match="Missing required environment variables"),
+        ):
+            M365ClientConfig.from_env()
+
+    def test_from_env_empty_values_treated_as_missing(self) -> None:
+        """Test empty string values are treated as missing."""
+        env_vars = {
+            "KW_TENANT_ID": "",  # Empty
+            "KW_APP_ID": "env-app-id",
+            "KW_CLIENT_SECRET": "env-secret",
+        }
+
+        with (
+            patch.dict(os.environ, env_vars, clear=True),
+            pytest.raises(ValueError, match="KW_TENANT_ID"),
+        ):
+            M365ClientConfig.from_env()
+
+
+# =============================================================================
+# UNIT TESTS - M365Client Wrapper
+# =============================================================================
+
+
+class TestM365Client:
+    """Tests for M365Client wrapper class."""
+
+    def test_client_creation(self) -> None:
+        """Test M365Client wrapper creation."""
+        mock_graph_client = MagicMock()
+
+        client = M365Client(graph_client=mock_graph_client)
+
+        assert client._graph_client is mock_graph_client
+
+    def test_graph_property(self) -> None:
+        """Test graph property returns underlying client."""
+        mock_graph_client = MagicMock()
+        mock_graph_client.users = MagicMock()
+
+        client = M365Client(graph_client=mock_graph_client)
+
+        assert client.graph is mock_graph_client
+        assert client.graph.users is mock_graph_client.users
+
+    def test_graph_property_access_multiple_times(self) -> None:
+        """Test graph property returns same instance."""
+        mock_graph_client = MagicMock()
+
+        client = M365Client(graph_client=mock_graph_client)
+
+        # Multiple accesses should return same object
+        assert client.graph is client.graph
+        assert id(client.graph) == id(mock_graph_client)
+
+
+# =============================================================================
+# UNIT TESTS - M365ClientFactory
+# =============================================================================
+
+
+class TestM365ClientFactory:
+    """Tests for M365ClientFactory."""
+
+    @patch("azure_haymaker.knowledge_worker.m365_client.GraphServiceClient")
+    @patch("azure_haymaker.knowledge_worker.m365_client.ClientSecretCredential")
+    def test_create_with_config(
+        self,
+        mock_credential_class: MagicMock,
+        mock_graph_client_class: MagicMock,
+    ) -> None:
+        """Test factory creates client with provided config."""
+        mock_credential = MagicMock()
+        mock_credential_class.return_value = mock_credential
+
+        mock_graph_client = MagicMock()
+        mock_graph_client_class.return_value = mock_graph_client
+
+        config = M365ClientConfig(
+            tenant_id="test-tenant",
+            client_id="test-client",
+            client_secret="test-secret",
+        )
+
+        client = M365ClientFactory.create(config=config)
+
+        # Verify credential was created with correct params
+        mock_credential_class.assert_called_once_with(
+            tenant_id="test-tenant",
+            client_id="test-client",
+            client_secret="test-secret",
+        )
+
+        # Verify GraphServiceClient was created with credential and scopes
+        mock_graph_client_class.assert_called_once_with(
+            mock_credential,
+            scopes=["https://graph.microsoft.com/.default"],
+        )
+
+        # Verify returned client wraps the graph client
+        assert isinstance(client, M365Client)
+        assert client.graph is mock_graph_client
+
+    @patch("azure_haymaker.knowledge_worker.m365_client.GraphServiceClient")
+    @patch("azure_haymaker.knowledge_worker.m365_client.ClientSecretCredential")
+    @patch("azure_haymaker.knowledge_worker.m365_client.M365ClientConfig.from_env")
+    def test_create_without_config_uses_env(
+        self,
+        mock_from_env: MagicMock,
+        mock_credential_class: MagicMock,
+        mock_graph_client_class: MagicMock,
+    ) -> None:
+        """Test factory loads config from env when not provided."""
+        mock_from_env.return_value = M365ClientConfig(
+            tenant_id="env-tenant",
+            client_id="env-client",
+            client_secret="env-secret",
+        )
+        mock_credential = MagicMock()
+        mock_credential_class.return_value = mock_credential
+        mock_graph_client = MagicMock()
+        mock_graph_client_class.return_value = mock_graph_client
+
+        M365ClientFactory.create()
+
+        mock_from_env.assert_called_once()
+        mock_credential_class.assert_called_once_with(
+            tenant_id="env-tenant",
+            client_id="env-client",
+            client_secret="env-secret",
+        )
+
+    @patch("azure_haymaker.knowledge_worker.m365_client.M365ClientConfig.from_env")
+    def test_create_propagates_config_error(
+        self,
+        mock_from_env: MagicMock,
+    ) -> None:
+        """Test factory propagates config loading errors."""
+        mock_from_env.side_effect = ValueError("Missing KW_TENANT_ID")
+
+        with pytest.raises(ValueError, match="Missing KW_TENANT_ID"):
+            M365ClientFactory.create()
+
+    @patch("azure_haymaker.knowledge_worker.m365_client.GraphServiceClient")
+    @patch("azure_haymaker.knowledge_worker.m365_client.ClientSecretCredential")
+    def test_create_uses_default_scopes(
+        self,
+        mock_credential_class: MagicMock,
+        mock_graph_client_class: MagicMock,
+    ) -> None:
+        """Test factory uses correct Graph API scopes."""
+        mock_credential = MagicMock()
+        mock_credential_class.return_value = mock_credential
+        mock_graph_client = MagicMock()
+        mock_graph_client_class.return_value = mock_graph_client
+
+        config = M365ClientConfig(
+            tenant_id="test-tenant",
+            client_id="test-client",
+            client_secret="test-secret",
+        )
+
+        M365ClientFactory.create(config=config)
+
+        # Verify correct scope is used
+        call_kwargs = mock_graph_client_class.call_args[1]
+        assert call_kwargs["scopes"] == ["https://graph.microsoft.com/.default"]
+
+
+# =============================================================================
+# INTEGRATION TESTS - Full Flow
+# =============================================================================
+
+
+class TestM365ClientIntegration:
+    """Integration tests for M365 client creation flow."""
+
+    @patch("azure_haymaker.knowledge_worker.m365_client.GraphServiceClient")
+    @patch("azure_haymaker.knowledge_worker.m365_client.ClientSecretCredential")
+    def test_full_client_creation_flow(
+        self,
+        mock_credential_class: MagicMock,
+        mock_graph_client_class: MagicMock,
+    ) -> None:
+        """Test complete client creation and usage flow."""
+        # Setup mocks
+        mock_credential = MagicMock()
+        mock_credential_class.return_value = mock_credential
+
+        mock_users = MagicMock()
+        mock_graph_client = MagicMock()
+        mock_graph_client.users = mock_users
+        mock_graph_client_class.return_value = mock_graph_client
+
+        # Create config
+        config = M365ClientConfig(
+            tenant_id="integration-tenant",
+            client_id="integration-client",
+            client_secret="integration-secret",
+        )
+
+        # Create client
+        client = M365ClientFactory.create(config=config)
+
+        # Verify client is properly configured
+        assert isinstance(client, M365Client)
+        assert client.graph is mock_graph_client
+        assert client.graph.users is mock_users
+
+        # Verify correct authentication was configured
+        mock_credential_class.assert_called_once_with(
+            tenant_id="integration-tenant",
+            client_id="integration-client",
+            client_secret="integration-secret",
+        )
+
+    def test_config_from_env_with_factory_integration(self) -> None:
+        """Test complete flow from environment to client."""
+        env_vars = {
+            "KW_TENANT_ID": "env-integration-tenant",
+            "KW_APP_ID": "env-integration-client",
+            "KW_CLIENT_SECRET": "env-integration-secret",
+        }
+
+        with (
+            patch.dict(os.environ, env_vars, clear=False),
+            patch("azure_haymaker.knowledge_worker.m365_client.GraphServiceClient") as mock_graph,
+            patch(
+                "azure_haymaker.knowledge_worker.m365_client.ClientSecretCredential"
+            ) as mock_cred,
+        ):
+            mock_cred.return_value = MagicMock()
+            mock_graph.return_value = MagicMock()
+
+            # Create client using environment variables
+            client = M365ClientFactory.create()
+
+            assert isinstance(client, M365Client)
+            mock_cred.assert_called_once_with(
+                tenant_id="env-integration-tenant",
+                client_id="env-integration-client",
+                client_secret="env-integration-secret",
+            )
+
+
+# =============================================================================
+# UNIT TESTS - Error Handling
+# =============================================================================
+
+
+class TestM365ClientErrorHandling:
+    """Tests for error handling scenarios."""
+
+    @patch("azure_haymaker.knowledge_worker.m365_client.ClientSecretCredential")
+    def test_credential_creation_error(
+        self,
+        mock_credential_class: MagicMock,
+    ) -> None:
+        """Test handling of credential creation errors."""
+        mock_credential_class.side_effect = Exception("Invalid credentials")
+
+        config = M365ClientConfig(
+            tenant_id="test-tenant",
+            client_id="test-client",
+            client_secret="invalid-secret",
+        )
+
+        with pytest.raises(Exception, match="Invalid credentials"):
+            M365ClientFactory.create(config=config)
+
+    @patch("azure_haymaker.knowledge_worker.m365_client.GraphServiceClient")
+    @patch("azure_haymaker.knowledge_worker.m365_client.ClientSecretCredential")
+    def test_graph_client_creation_error(
+        self,
+        mock_credential_class: MagicMock,
+        mock_graph_client_class: MagicMock,
+    ) -> None:
+        """Test handling of Graph client creation errors."""
+        mock_credential = MagicMock()
+        mock_credential_class.return_value = mock_credential
+        mock_graph_client_class.side_effect = Exception("Failed to create client")
+
+        config = M365ClientConfig(
+            tenant_id="test-tenant",
+            client_id="test-client",
+            client_secret="test-secret",
+        )
+
+        with pytest.raises(Exception, match="Failed to create client"):
+            M365ClientFactory.create(config=config)
+
+
+# =============================================================================
+# UNIT TESTS - Security Considerations
+# =============================================================================
+
+
+class TestM365ClientSecurity:
+    """Tests for security-related behavior."""
+
+    def test_config_secret_not_in_string(self) -> None:
+        """Test client_secret doesn't appear in string representations."""
+        config = M365ClientConfig(
+            tenant_id="tenant-123",
+            client_id="client-456",
+            client_secret="my-super-secret-key",
+        )
+
+        # Convert to various string representations
+        str_repr = str(config)
+        repr_str = repr(config)
+
+        # Secret should never appear
+        assert "my-super-secret-key" not in str_repr
+        assert "my-super-secret-key" not in repr_str
+
+    @patch("azure_haymaker.knowledge_worker.m365_client.GraphServiceClient")
+    @patch("azure_haymaker.knowledge_worker.m365_client.ClientSecretCredential")
+    def test_secret_not_stored_in_client(
+        self,
+        mock_credential_class: MagicMock,
+        mock_graph_client_class: MagicMock,
+    ) -> None:
+        """Test client doesn't expose the secret after creation."""
+        mock_credential = MagicMock()
+        mock_credential_class.return_value = mock_credential
+        mock_graph_client = MagicMock()
+        mock_graph_client_class.return_value = mock_graph_client
+
+        config = M365ClientConfig(
+            tenant_id="test-tenant",
+            client_id="test-client",
+            client_secret="sensitive-secret",
+        )
+
+        client = M365ClientFactory.create(config=config)
+
+        # Client should not have direct access to secret
+        assert not hasattr(client, "client_secret")
+        assert not hasattr(client, "_client_secret")
+
+        # Check string representation doesn't leak
+        client_str = str(client)
+        assert "sensitive-secret" not in client_str

--- a/tests/unit/test_worker_registry.py
+++ b/tests/unit/test_worker_registry.py
@@ -1,0 +1,581 @@
+"""Tests for worker_registry module.
+
+Comprehensive unit tests for the WorkerRegistry class including:
+- Worker registration and unregistration
+- Worker lookup operations
+- UPN retrieval
+- Department filtering
+- Random recipient selection
+- Registry queries
+- Cleanup operations
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from azure_haymaker.knowledge_worker.models.worker import WorkerIdentity, WorkerPersona
+from azure_haymaker.knowledge_worker.worker_registry import WorkerRegistry
+
+if TYPE_CHECKING:
+    pass
+
+
+# =============================================================================
+# FIXTURES
+# =============================================================================
+
+
+@pytest.fixture
+def sample_workers() -> list[WorkerIdentity]:
+    """Create sample worker identities for testing."""
+    return [
+        WorkerIdentity(
+            worker_id="kw-eng-001",
+            display_name="Alice Engineer",
+            user_principal_name="alice@tenant.onmicrosoft.com",
+            department="engineering",
+            persona=WorkerPersona.ENGINEERING,
+        ),
+        WorkerIdentity(
+            worker_id="kw-eng-002",
+            display_name="Bob Engineer",
+            user_principal_name="bob@tenant.onmicrosoft.com",
+            department="engineering",
+            persona=WorkerPersona.ENGINEERING,
+        ),
+        WorkerIdentity(
+            worker_id="kw-hr-001",
+            display_name="Carol HR",
+            user_principal_name="carol@tenant.onmicrosoft.com",
+            department="hr",
+            persona=WorkerPersona.HR,
+        ),
+        WorkerIdentity(
+            worker_id="kw-sales-001",
+            display_name="Dave Sales",
+            user_principal_name="dave@tenant.onmicrosoft.com",
+            department="sales",
+            persona=WorkerPersona.SALES,
+        ),
+        WorkerIdentity(
+            worker_id="kw-exec-001",
+            display_name="Eve Executive",
+            user_principal_name="eve@tenant.onmicrosoft.com",
+            department="executive",
+            persona=WorkerPersona.EXECUTIVE,
+        ),
+    ]
+
+
+@pytest.fixture
+def populated_registry(sample_workers: list[WorkerIdentity]) -> WorkerRegistry:
+    """Create a registry populated with sample workers."""
+    registry = WorkerRegistry(run_id="kw-test-12345")
+    for worker in sample_workers:
+        registry.register(worker)
+    return registry
+
+
+@pytest.fixture
+def empty_registry() -> WorkerRegistry:
+    """Create an empty registry."""
+    return WorkerRegistry(run_id="kw-empty-00000")
+
+
+# =============================================================================
+# UNIT TESTS - Registry Creation
+# =============================================================================
+
+
+class TestRegistryCreation:
+    """Tests for WorkerRegistry creation."""
+
+    def test_create_empty_registry(self) -> None:
+        """Test creating an empty registry."""
+        registry = WorkerRegistry(run_id="kw-abc12345")
+
+        assert registry.run_id == "kw-abc12345"
+        assert registry.worker_count == 0
+
+    def test_registry_run_id_stored(self) -> None:
+        """Test that run_id is stored correctly."""
+        registry = WorkerRegistry(run_id="kw-xyz98765")
+
+        assert registry.run_id == "kw-xyz98765"
+
+
+# =============================================================================
+# UNIT TESTS - Worker Registration
+# =============================================================================
+
+
+class TestWorkerRegistration:
+    """Tests for worker registration operations."""
+
+    def test_register_single_worker(self, empty_registry: WorkerRegistry) -> None:
+        """Test registering a single worker."""
+        worker = WorkerIdentity(
+            worker_id="kw-eng-001",
+            display_name="Test Worker",
+            user_principal_name="test@tenant.onmicrosoft.com",
+            department="engineering",
+            persona=WorkerPersona.ENGINEERING,
+        )
+
+        empty_registry.register(worker)
+
+        assert empty_registry.worker_count == 1
+        assert empty_registry.get("kw-eng-001") is not None
+
+    def test_register_multiple_workers(
+        self, empty_registry: WorkerRegistry, sample_workers: list[WorkerIdentity]
+    ) -> None:
+        """Test registering multiple workers."""
+        for worker in sample_workers:
+            empty_registry.register(worker)
+
+        assert empty_registry.worker_count == len(sample_workers)
+
+    def test_register_duplicate_worker_overwrites(self, empty_registry: WorkerRegistry) -> None:
+        """Test registering a worker with same ID overwrites existing."""
+        worker1 = WorkerIdentity(
+            worker_id="kw-eng-001",
+            display_name="Original Name",
+            user_principal_name="original@tenant.onmicrosoft.com",
+            department="engineering",
+            persona=WorkerPersona.ENGINEERING,
+        )
+        worker2 = WorkerIdentity(
+            worker_id="kw-eng-001",  # Same ID
+            display_name="Updated Name",
+            user_principal_name="updated@tenant.onmicrosoft.com",
+            department="engineering",
+            persona=WorkerPersona.ENGINEERING,
+        )
+
+        empty_registry.register(worker1)
+        empty_registry.register(worker2)
+
+        assert empty_registry.worker_count == 1
+        assert empty_registry.get("kw-eng-001").display_name == "Updated Name"
+
+
+# =============================================================================
+# UNIT TESTS - Worker Unregistration
+# =============================================================================
+
+
+class TestWorkerUnregistration:
+    """Tests for worker unregistration operations."""
+
+    def test_unregister_existing_worker(self, populated_registry: WorkerRegistry) -> None:
+        """Test unregistering an existing worker."""
+        initial_count = populated_registry.worker_count
+
+        populated_registry.unregister("kw-eng-001")
+
+        assert populated_registry.worker_count == initial_count - 1
+        assert populated_registry.get("kw-eng-001") is None
+
+    def test_unregister_nonexistent_worker(self, populated_registry: WorkerRegistry) -> None:
+        """Test unregistering a non-existent worker does nothing."""
+        initial_count = populated_registry.worker_count
+
+        populated_registry.unregister("nonexistent-worker")
+
+        assert populated_registry.worker_count == initial_count
+
+    def test_unregister_all_workers(
+        self, populated_registry: WorkerRegistry, sample_workers: list[WorkerIdentity]
+    ) -> None:
+        """Test unregistering all workers."""
+        for worker in sample_workers:
+            populated_registry.unregister(worker.worker_id)
+
+        assert populated_registry.worker_count == 0
+
+
+# =============================================================================
+# UNIT TESTS - Worker Lookup
+# =============================================================================
+
+
+class TestWorkerLookup:
+    """Tests for worker lookup operations."""
+
+    def test_get_existing_worker(self, populated_registry: WorkerRegistry) -> None:
+        """Test getting an existing worker by ID."""
+        worker = populated_registry.get("kw-eng-001")
+
+        assert worker is not None
+        assert worker.worker_id == "kw-eng-001"
+        assert worker.display_name == "Alice Engineer"
+
+    def test_get_nonexistent_worker(self, populated_registry: WorkerRegistry) -> None:
+        """Test getting a non-existent worker returns None."""
+        worker = populated_registry.get("nonexistent-worker")
+
+        assert worker is None
+
+    def test_get_from_empty_registry(self, empty_registry: WorkerRegistry) -> None:
+        """Test getting from empty registry returns None."""
+        worker = empty_registry.get("any-worker")
+
+        assert worker is None
+
+
+# =============================================================================
+# UNIT TESTS - Get All Workers
+# =============================================================================
+
+
+class TestGetAllWorkers:
+    """Tests for getting all workers."""
+
+    def test_get_all_workers(
+        self, populated_registry: WorkerRegistry, sample_workers: list[WorkerIdentity]
+    ) -> None:
+        """Test getting all registered workers."""
+        workers = populated_registry.get_all_workers()
+
+        assert len(workers) == len(sample_workers)
+        worker_ids = {w.worker_id for w in workers}
+        expected_ids = {w.worker_id for w in sample_workers}
+        assert worker_ids == expected_ids
+
+    def test_get_all_workers_empty_registry(self, empty_registry: WorkerRegistry) -> None:
+        """Test getting all workers from empty registry."""
+        workers = empty_registry.get_all_workers()
+
+        assert len(workers) == 0
+        assert workers == []
+
+
+# =============================================================================
+# UNIT TESTS - Get All UPNs
+# =============================================================================
+
+
+class TestGetAllUPNs:
+    """Tests for getting all user principal names."""
+
+    def test_get_all_upns(self, populated_registry: WorkerRegistry) -> None:
+        """Test getting all UPNs."""
+        upns = populated_registry.get_all_upns()
+
+        assert len(upns) == 5
+        assert "alice@tenant.onmicrosoft.com" in upns
+        assert "bob@tenant.onmicrosoft.com" in upns
+        assert "carol@tenant.onmicrosoft.com" in upns
+
+    def test_get_all_upns_empty_registry(self, empty_registry: WorkerRegistry) -> None:
+        """Test getting UPNs from empty registry."""
+        upns = empty_registry.get_all_upns()
+
+        assert upns == []
+
+    def test_get_all_upns_excludes_empty(self, empty_registry: WorkerRegistry) -> None:
+        """Test that workers with empty UPN are excluded."""
+        worker_with_upn = WorkerIdentity(
+            worker_id="kw-eng-001",
+            display_name="Worker With UPN",
+            user_principal_name="worker@tenant.com",
+            department="engineering",
+            persona=WorkerPersona.ENGINEERING,
+        )
+        worker_without_upn = WorkerIdentity(
+            worker_id="kw-eng-002",
+            display_name="Worker Without UPN",
+            user_principal_name="",  # Empty UPN
+            department="engineering",
+            persona=WorkerPersona.ENGINEERING,
+        )
+
+        empty_registry.register(worker_with_upn)
+        empty_registry.register(worker_without_upn)
+
+        upns = empty_registry.get_all_upns()
+
+        assert len(upns) == 1
+        assert "worker@tenant.com" in upns
+
+
+# =============================================================================
+# UNIT TESTS - Department Filtering
+# =============================================================================
+
+
+class TestDepartmentFiltering:
+    """Tests for department-based worker filtering."""
+
+    def test_get_workers_by_department(self, populated_registry: WorkerRegistry) -> None:
+        """Test filtering workers by department."""
+        engineering_workers = populated_registry.get_workers_by_department("engineering")
+
+        assert len(engineering_workers) == 2
+        for worker in engineering_workers:
+            assert worker.department.lower() == "engineering"
+
+    def test_get_workers_by_department_case_insensitive(
+        self, populated_registry: WorkerRegistry
+    ) -> None:
+        """Test department filtering is case-insensitive."""
+        workers_lower = populated_registry.get_workers_by_department("engineering")
+        workers_upper = populated_registry.get_workers_by_department("ENGINEERING")
+        workers_mixed = populated_registry.get_workers_by_department("EnGiNeErInG")
+
+        assert len(workers_lower) == len(workers_upper) == len(workers_mixed)
+
+    def test_get_workers_nonexistent_department(self, populated_registry: WorkerRegistry) -> None:
+        """Test filtering by non-existent department returns empty."""
+        workers = populated_registry.get_workers_by_department("nonexistent")
+
+        assert workers == []
+
+    def test_get_workers_by_department_single_match(
+        self, populated_registry: WorkerRegistry
+    ) -> None:
+        """Test filtering with single worker in department."""
+        hr_workers = populated_registry.get_workers_by_department("hr")
+
+        assert len(hr_workers) == 1
+        assert hr_workers[0].worker_id == "kw-hr-001"
+
+
+# =============================================================================
+# UNIT TESTS - Random Recipients
+# =============================================================================
+
+
+class TestRandomRecipients:
+    """Tests for random recipient selection."""
+
+    def test_get_random_recipients_single(self, populated_registry: WorkerRegistry) -> None:
+        """Test getting a single random recipient."""
+        recipients = populated_registry.get_random_recipients(
+            exclude="kw-eng-001",
+            count=1,
+        )
+
+        assert len(recipients) == 1
+        assert "alice@tenant.onmicrosoft.com" not in recipients
+
+    def test_get_random_recipients_multiple(self, populated_registry: WorkerRegistry) -> None:
+        """Test getting multiple random recipients."""
+        recipients = populated_registry.get_random_recipients(
+            exclude="kw-eng-001",
+            count=3,
+        )
+
+        assert len(recipients) == 3
+        assert "alice@tenant.onmicrosoft.com" not in recipients
+
+    def test_get_random_recipients_excludes_self(self, populated_registry: WorkerRegistry) -> None:
+        """Test that excluded worker is never in results."""
+        # Run multiple times to test randomness
+        for _ in range(10):
+            recipients = populated_registry.get_random_recipients(
+                exclude="kw-eng-001",
+                count=4,
+            )
+            assert "alice@tenant.onmicrosoft.com" not in recipients
+
+    def test_get_random_recipients_more_than_available(
+        self, populated_registry: WorkerRegistry
+    ) -> None:
+        """Test requesting more recipients than available."""
+        # Excluding one worker, only 4 candidates remain
+        recipients = populated_registry.get_random_recipients(
+            exclude="kw-eng-001",
+            count=10,  # More than available
+        )
+
+        assert len(recipients) == 4  # Returns all available
+
+    def test_get_random_recipients_empty_registry(self, empty_registry: WorkerRegistry) -> None:
+        """Test getting recipients from empty registry."""
+        recipients = empty_registry.get_random_recipients(
+            exclude="any-worker",
+            count=1,
+        )
+
+        assert recipients == []
+
+
+# =============================================================================
+# UNIT TESTS - Random Recipients from Department
+# =============================================================================
+
+
+class TestRandomRecipientsFromDepartment:
+    """Tests for department-specific random recipient selection."""
+
+    def test_get_random_recipients_from_department(
+        self, populated_registry: WorkerRegistry
+    ) -> None:
+        """Test getting random recipients from specific department."""
+        recipients = populated_registry.get_random_recipients_from_department(
+            exclude="kw-eng-001",
+            department="engineering",
+            count=1,
+        )
+
+        assert len(recipients) == 1
+        assert recipients[0] == "bob@tenant.onmicrosoft.com"
+
+    def test_get_random_recipients_department_excludes_self(
+        self, populated_registry: WorkerRegistry
+    ) -> None:
+        """Test department recipients excludes sender."""
+        recipients = populated_registry.get_random_recipients_from_department(
+            exclude="kw-eng-002",
+            department="engineering",
+            count=1,
+        )
+
+        assert len(recipients) == 1
+        assert "bob@tenant.onmicrosoft.com" not in recipients
+
+    def test_get_random_recipients_nonexistent_department(
+        self, populated_registry: WorkerRegistry
+    ) -> None:
+        """Test getting recipients from non-existent department."""
+        recipients = populated_registry.get_random_recipients_from_department(
+            exclude="kw-eng-001",
+            department="nonexistent",
+            count=1,
+        )
+
+        assert recipients == []
+
+    def test_get_random_recipients_department_case_insensitive(
+        self, populated_registry: WorkerRegistry
+    ) -> None:
+        """Test department name is case-insensitive."""
+        recipients_lower = populated_registry.get_random_recipients_from_department(
+            exclude="kw-eng-001",
+            department="engineering",
+            count=1,
+        )
+        recipients_upper = populated_registry.get_random_recipients_from_department(
+            exclude="kw-eng-001",
+            department="ENGINEERING",
+            count=1,
+        )
+
+        # Both should return the same single candidate (bob)
+        assert recipients_lower == recipients_upper
+
+
+# =============================================================================
+# UNIT TESTS - Worker Count Property
+# =============================================================================
+
+
+class TestWorkerCount:
+    """Tests for worker_count property."""
+
+    def test_worker_count_empty(self, empty_registry: WorkerRegistry) -> None:
+        """Test worker count on empty registry."""
+        assert empty_registry.worker_count == 0
+
+    def test_worker_count_after_registration(
+        self, empty_registry: WorkerRegistry, sample_workers: list[WorkerIdentity]
+    ) -> None:
+        """Test worker count increases after registration."""
+        for i, worker in enumerate(sample_workers):
+            empty_registry.register(worker)
+            assert empty_registry.worker_count == i + 1
+
+    def test_worker_count_after_unregistration(self, populated_registry: WorkerRegistry) -> None:
+        """Test worker count decreases after unregistration."""
+        initial_count = populated_registry.worker_count
+
+        populated_registry.unregister("kw-eng-001")
+        assert populated_registry.worker_count == initial_count - 1
+
+        populated_registry.unregister("kw-hr-001")
+        assert populated_registry.worker_count == initial_count - 2
+
+
+# =============================================================================
+# INTEGRATION TESTS - Full Workflow
+# =============================================================================
+
+
+class TestRegistryIntegration:
+    """Integration tests for registry workflows."""
+
+    def test_full_lifecycle(self) -> None:
+        """Test complete registry lifecycle."""
+        # Create registry
+        registry = WorkerRegistry(run_id="kw-lifecycle-test")
+        assert registry.worker_count == 0
+
+        # Register workers
+        workers = [
+            WorkerIdentity(
+                worker_id=f"kw-test-{i:03d}",
+                display_name=f"Test Worker {i}",
+                user_principal_name=f"worker{i}@tenant.com",
+                department="testing",
+                persona=WorkerPersona.ENGINEERING,
+            )
+            for i in range(5)
+        ]
+
+        for worker in workers:
+            registry.register(worker)
+        assert registry.worker_count == 5
+
+        # Query workers
+        all_workers = registry.get_all_workers()
+        assert len(all_workers) == 5
+
+        all_upns = registry.get_all_upns()
+        assert len(all_upns) == 5
+
+        testing_workers = registry.get_workers_by_department("testing")
+        assert len(testing_workers) == 5
+
+        # Get random recipients
+        recipients = registry.get_random_recipients(
+            exclude="kw-test-000",
+            count=2,
+        )
+        assert len(recipients) == 2
+        assert "worker0@tenant.com" not in recipients
+
+        # Unregister some workers
+        registry.unregister("kw-test-000")
+        registry.unregister("kw-test-001")
+        assert registry.worker_count == 3
+
+        # Verify lookup
+        assert registry.get("kw-test-000") is None
+        assert registry.get("kw-test-002") is not None
+
+    def test_cross_department_communication(self, populated_registry: WorkerRegistry) -> None:
+        """Test simulating cross-department email recipients."""
+        # Engineering worker wants to email HR
+        hr_recipients = populated_registry.get_random_recipients_from_department(
+            exclude="kw-eng-001",
+            department="hr",
+            count=1,
+        )
+
+        assert len(hr_recipients) == 1
+        assert hr_recipients[0] == "carol@tenant.onmicrosoft.com"
+
+        # HR worker wants to email Engineering
+        eng_recipients = populated_registry.get_random_recipients_from_department(
+            exclude="kw-hr-001",
+            department="engineering",
+            count=2,
+        )
+
+        assert len(eng_recipients) == 2
+        assert "carol@tenant.onmicrosoft.com" not in eng_recipients


### PR DESCRIPTION
## Summary
- Add 118 new unit tests for 4 modules lacking test coverage
- `test_email_generator.py` (31 tests): AI email content generation with Anthropic API mocks
- `test_github_client.py` (32 tests): GitHub API operations (commits, PRs, reviews, workflows)
- `test_worker_registry.py` (34 tests): Worker registration and lifecycle management  
- `test_m365_client.py` (21 tests): M365 Graph API client factory and authentication

## Test Coverage
All tests mock external APIs appropriately and follow pytest best practices:
- Comprehensive input validation testing
- Error handling and edge cases
- Security considerations (API key redaction, XSS prevention)
- Async support where needed

## Test Results
All 118 tests pass locally:
```
================= 118 passed, 2 warnings in 218.50s (0:03:38) ==================
```

## Test plan
- [x] All 118 tests pass with pytest
- [x] Ruff linting passes
- [x] No breaking changes to existing code

🤖 Generated with [Claude Code](https://claude.com/claude-code)