### PR TITLE
refactor: Remove unused dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,12 +36,10 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "croniter>=2.0.0",
     "playwright>=1.40.0",
-    "pywinrm>=0.4.3",
     "pyyaml>=6.0.1",
     # OpenTelemetry - Distributed tracing
     "opentelemetry-api>=1.21.0",
     "opentelemetry-sdk>=1.21.0",
-    "opentelemetry-instrumentation-fastapi>=0.42b0",
     "azure-monitor-opentelemetry-exporter>=1.0.0b21",
     "fastapi>=0.100.0",
     "uvicorn>=0.30.0",


### PR DESCRIPTION
Remove pywinrm and opentelemetry-instrumentation-fastapi - zero imports found. Closes #273